### PR TITLE
Update Contributing link in build targets

### DIFF
--- a/content/building/build-esp32.md
+++ b/content/building/build-esp32.md
@@ -59,7 +59,7 @@ The setup is a lot easier than it seems. The setup scripts do almost everything.
 
 If you intend to change the nanoCLR and create Pull Requests then you will need to fork the [nanoFramework/nf-interpreter](https://github.com/nanoFramework/nf-interpreter) to your own GitHub repo and clone the forked GitHub repo to your Windows system using an Git client such as [Fork](https://fork.dev) or the [GitHub Desktop application](https://desktop.github.com).
 
-The _develop_ branch is the default working branch. When working on a fix or experimenting a new feature you should do it on another branch. See the [Contributing guide](../../content/contributing/) for specific instructions on the suggested contributing workflow.
+The _develop_ branch is the default working branch. When working on a fix or experimenting a new feature you should do it on another branch. See the [Contributing guide](../contributing/contributing-workflow.md#suggested-workflow) for specific instructions on the suggested contributing workflow.
 
 If you don't intend to make changes to the nanoBooter and nanoCLR, you can clone [nanoFramework/nf-interpreter](https://github.com/nanoFramework/nf-interpreter) directly from here.
 

--- a/content/building/build-esp32.md
+++ b/content/building/build-esp32.md
@@ -59,7 +59,7 @@ The setup is a lot easier than it seems. The setup scripts do almost everything.
 
 If you intend to change the nanoCLR and create Pull Requests then you will need to fork the [nanoFramework/nf-interpreter](https://github.com/nanoFramework/nf-interpreter) to your own GitHub repo and clone the forked GitHub repo to your Windows system using an Git client such as [Fork](https://fork.dev) or the [GitHub Desktop application](https://desktop.github.com).
 
-The _develop_ branch is the default working branch. When working on a fix or experimenting a new feature you should do it on another branch. See the [Contributing guide](../../content/contributing/) for specific instructions on the suggested contributing workflow.
+The _develop_ branch is the default working branch. When working on a fix or experimenting a new feature you should do it on another branch. See the [Contributing guide](..\..\content\contributing\contributing-workflow.md#suggested-workflow) for specific instructions on the suggested contributing workflow.
 
 If you don't intend to make changes to the nanoBooter and nanoCLR, you can clone [nanoFramework/nf-interpreter](https://github.com/nanoFramework/nf-interpreter) directly from here.
 

--- a/content/building/build-esp32.md
+++ b/content/building/build-esp32.md
@@ -59,7 +59,7 @@ The setup is a lot easier than it seems. The setup scripts do almost everything.
 
 If you intend to change the nanoCLR and create Pull Requests then you will need to fork the [nanoFramework/nf-interpreter](https://github.com/nanoFramework/nf-interpreter) to your own GitHub repo and clone the forked GitHub repo to your Windows system using an Git client such as [Fork](https://fork.dev) or the [GitHub Desktop application](https://desktop.github.com).
 
-The _develop_ branch is the default working branch. When working on a fix or experimenting a new feature you should do it on another branch. See the [Contributing guide](..\..\content\contributing\contributing-workflow.md#suggested-workflow) for specific instructions on the suggested contributing workflow.
+The _develop_ branch is the default working branch. When working on a fix or experimenting a new feature you should do it on another branch. See the [Contributing guide](../../content/contributing/) for specific instructions on the suggested contributing workflow.
 
 If you don't intend to make changes to the nanoBooter and nanoCLR, you can clone [nanoFramework/nf-interpreter](https://github.com/nanoFramework/nf-interpreter) directly from here.
 

--- a/content/building/build-nxp.md
+++ b/content/building/build-nxp.md
@@ -62,7 +62,7 @@ The setup is a lot easier than it seems. The setup scripts do almost everything.
 
 If you intend to change the nanoBooter or nanoCLR and create Pull Requests then you will need to fork the [nanoFramework/nf-interpreter](https://github.com/nanoFramework/nf-interpreter) to your own GitHub repo and clone the forked GitHub repo to your Windows system using an Git client such as the [GitHub Desktop application](https://desktop.github.com/).
 
-The _develop_ branch is the default working branch. When working on a fix or experimenting a new feature you should do it on another branch. See the [Contributing guide](..\..\content\contributing) for specific instructions on the suggested contributing workflow.
+The _develop_ branch is the default working branch. When working on a fix or experimenting a new feature you should do it on another branch. See the [Contributing guide](..\content\contributing) for specific instructions on the suggested contributing workflow.
 
 If you don't intend to make changes to the nanoBooter and nanoCLR, you can clone [nanoFramework/nf-interpreter](https://github.com/nanoFramework/nf-interpreter) directly from here.
 

--- a/content/building/build-nxp.md
+++ b/content/building/build-nxp.md
@@ -100,7 +100,7 @@ After cloning the repo, you need to setup the build environment. You can use the
 
 ### Automated Install of the build environment
 
-__Run Power Shell as an Administrator and run `set-executionpolicy RemoteSigned` to enable execution of the signed script.
+__Run Power Shell as an Administrator and run `set-executionpolicy RemoteSigned` to enable execution of the signed script,
 otherwise if the following power shell script is not signed `set-executionpolicy Unrestricted` to enable execution of the non-signed script.__
 
 On Windows, one may use the `.\install-nf-tools.ps1` Power Shell script located in the repository `install-scripts` folder to download/install CMake, the toolchain, OpenOCD (for JTAG debugging) and Ninja. You may need to use __Run as Administrator__ for power shell to permit installing modules to unzip the downloaded archives.

--- a/content/building/build-nxp.md
+++ b/content/building/build-nxp.md
@@ -62,7 +62,7 @@ The setup is a lot easier than it seems. The setup scripts do almost everything.
 
 If you intend to change the nanoBooter or nanoCLR and create Pull Requests then you will need to fork the [nanoFramework/nf-interpreter](https://github.com/nanoFramework/nf-interpreter) to your own GitHub repo and clone the forked GitHub repo to your Windows system using an Git client such as the [GitHub Desktop application](https://desktop.github.com/).
 
-The _develop_ branch is the default working branch. When working on a fix or experimenting a new feature you should do it on another branch. See the [Contributing guide](https://github.com/nanoframework/nanoframework.github.io/tree/pages-source/content/contributing) for specific instructions on the suggested contributing workflow.
+The _develop_ branch is the default working branch. When working on a fix or experimenting a new feature you should do it on another branch. See the [Contributing guide](..\..\content\contributing) for specific instructions on the suggested contributing workflow.
 
 If you don't intend to make changes to the nanoBooter and nanoCLR, you can clone [nanoFramework/nf-interpreter](https://github.com/nanoFramework/nf-interpreter) directly from here.
 

--- a/content/building/build-nxp.md
+++ b/content/building/build-nxp.md
@@ -100,7 +100,8 @@ After cloning the repo, you need to setup the build environment. You can use the
 
 ### Automated Install of the build environment
 
-__The following power shell script is not signed. Run Power Shell as an Administrator and run `set-executionpolicy Unrestricted` to enable execution of the non-signed script.__
+__Run Power Shell as an Administrator and run `set-executionpolicy RemoteSigned` to enable execution of the signed script.
+otherwise if the following power shell script is not signed `set-executionpolicy Unrestricted` to enable execution of the non-signed script.__
 
 On Windows, one may use the `.\install-nf-tools.ps1` Power Shell script located in the repository `install-scripts` folder to download/install CMake, the toolchain, OpenOCD (for JTAG debugging) and Ninja. You may need to use __Run as Administrator__ for power shell to permit installing modules to unzip the downloaded archives.
 The script will download the zips and installers into the repository `zips` folder and extract them into sub-folders of the nanoFramework tools folder `C:\nftools` or install the tool.

--- a/content/building/build-nxp.md
+++ b/content/building/build-nxp.md
@@ -62,7 +62,7 @@ The setup is a lot easier than it seems. The setup scripts do almost everything.
 
 If you intend to change the nanoBooter or nanoCLR and create Pull Requests then you will need to fork the [nanoFramework/nf-interpreter](https://github.com/nanoFramework/nf-interpreter) to your own GitHub repo and clone the forked GitHub repo to your Windows system using an Git client such as the [GitHub Desktop application](https://desktop.github.com/).
 
-The _develop_ branch is the default working branch. When working on a fix or experimenting a new feature you should do it on another branch. See the [Contributing guide](../../content/contributing/) for specific instructions on the suggested contributing workflow.
+The _develop_ branch is the default working branch. When working on a fix or experimenting a new feature you should do it on another branch. See the [Contributing guide](../contributing/contributing-workflow.md#suggested-workflow) for specific instructions on the suggested contributing workflow.
 
 If you don't intend to make changes to the nanoBooter and nanoCLR, you can clone [nanoFramework/nf-interpreter](https://github.com/nanoFramework/nf-interpreter) directly from here.
 

--- a/content/building/build-nxp.md
+++ b/content/building/build-nxp.md
@@ -62,7 +62,7 @@ The setup is a lot easier than it seems. The setup scripts do almost everything.
 
 If you intend to change the nanoBooter or nanoCLR and create Pull Requests then you will need to fork the [nanoFramework/nf-interpreter](https://github.com/nanoFramework/nf-interpreter) to your own GitHub repo and clone the forked GitHub repo to your Windows system using an Git client such as the [GitHub Desktop application](https://desktop.github.com/).
 
-The _develop_ branch is the default working branch. When working on a fix or experimenting a new feature you should do it on another branch. See the [Contributing guide](..\..\content\contributing\contributing-workflow.md#suggested-workflow) for specific instructions on the suggested contributing workflow.
+The _develop_ branch is the default working branch. When working on a fix or experimenting a new feature you should do it on another branch. See the [Contributing guide](https://github.com/nanoframework/nanoframework.github.io/tree/pages-source/content/contributing) for specific instructions on the suggested contributing workflow.
 
 If you don't intend to make changes to the nanoBooter and nanoCLR, you can clone [nanoFramework/nf-interpreter](https://github.com/nanoFramework/nf-interpreter) directly from here.
 
@@ -100,7 +100,7 @@ After cloning the repo, you need to setup the build environment. You can use the
 
 ### Automated Install of the build environment
 
-__The following power shell script is not signed. Run Power Shell as an Administrator and run `set-executionpolicy remotesigned` to enable execution of the non-signed script.__
+__The following power shell script is not signed. Run Power Shell as an Administrator and run `set-executionpolicy Unrestricted` to enable execution of the non-signed script.__
 
 On Windows, one may use the `.\install-nf-tools.ps1` Power Shell script located in the repository `install-scripts` folder to download/install CMake, the toolchain, OpenOCD (for JTAG debugging) and Ninja. You may need to use __Run as Administrator__ for power shell to permit installing modules to unzip the downloaded archives.
 The script will download the zips and installers into the repository `zips` folder and extract them into sub-folders of the nanoFramework tools folder `C:\nftools` or install the tool.

--- a/content/building/build-nxp.md
+++ b/content/building/build-nxp.md
@@ -62,7 +62,7 @@ The setup is a lot easier than it seems. The setup scripts do almost everything.
 
 If you intend to change the nanoBooter or nanoCLR and create Pull Requests then you will need to fork the [nanoFramework/nf-interpreter](https://github.com/nanoFramework/nf-interpreter) to your own GitHub repo and clone the forked GitHub repo to your Windows system using an Git client such as the [GitHub Desktop application](https://desktop.github.com/).
 
-The _develop_ branch is the default working branch. When working on a fix or experimenting a new feature you should do it on another branch. See the [Contributing guide](..\content\contributing) for specific instructions on the suggested contributing workflow.
+The _develop_ branch is the default working branch. When working on a fix or experimenting a new feature you should do it on another branch. See the [Contributing guide](../../content/contributing/) for specific instructions on the suggested contributing workflow.
 
 If you don't intend to make changes to the nanoBooter and nanoCLR, you can clone [nanoFramework/nf-interpreter](https://github.com/nanoFramework/nf-interpreter) directly from here.
 

--- a/content/building/build-stm32.md
+++ b/content/building/build-stm32.md
@@ -61,7 +61,7 @@ The setup is a lot easier than it seems. The setup scripts do almost everything.
 
 If you intend to change the nanoBooter or nanoCLR and create Pull Requests then you will need to fork the [nanoFramework/nf-interpreter](https://github.com/nanoFramework/nf-interpreter) to your own GitHub repo and clone the forked GitHub repo to your Windows system using an Git client such as the [GitHub Desktop application](https://desktop.github.com/).
 
-The _develop_ branch is the default working branch. When working on a fix or experimenting a new feature you should do it on another branch. See the [Contributing guide](../../content/contributing/) for specific instructions on the suggested contributing workflow.
+The _develop_ branch is the default working branch. When working on a fix or experimenting a new feature you should do it on another branch. See the [Contributing guide](..\..\content\contributing\contributing-workflow.md#suggested-workflow) for specific instructions on the suggested contributing workflow.
 
 If you don't intend to make changes to the nanoBooter and nanoCLR, you can clone [nanoFramework/nf-interpreter](https://github.com/nanoFramework/nf-interpreter) directly from here.
 

--- a/content/building/build-stm32.md
+++ b/content/building/build-stm32.md
@@ -61,7 +61,7 @@ The setup is a lot easier than it seems. The setup scripts do almost everything.
 
 If you intend to change the nanoBooter or nanoCLR and create Pull Requests then you will need to fork the [nanoFramework/nf-interpreter](https://github.com/nanoFramework/nf-interpreter) to your own GitHub repo and clone the forked GitHub repo to your Windows system using an Git client such as the [GitHub Desktop application](https://desktop.github.com/).
 
-The _develop_ branch is the default working branch. When working on a fix or experimenting a new feature you should do it on another branch. See the [Contributing guide](../../content/contributing/) for specific instructions on the suggested contributing workflow.
+The _develop_ branch is the default working branch. When working on a fix or experimenting a new feature you should do it on another branch. See the [Contributing guide](../contributing/contributing-workflow.md#suggested-workflow) for specific instructions on the suggested contributing workflow.
 
 If you don't intend to make changes to the nanoBooter and nanoCLR, you can clone [nanoFramework/nf-interpreter](https://github.com/nanoFramework/nf-interpreter) directly from here.
 

--- a/content/building/build-stm32.md
+++ b/content/building/build-stm32.md
@@ -61,7 +61,7 @@ The setup is a lot easier than it seems. The setup scripts do almost everything.
 
 If you intend to change the nanoBooter or nanoCLR and create Pull Requests then you will need to fork the [nanoFramework/nf-interpreter](https://github.com/nanoFramework/nf-interpreter) to your own GitHub repo and clone the forked GitHub repo to your Windows system using an Git client such as the [GitHub Desktop application](https://desktop.github.com/).
 
-The _develop_ branch is the default working branch. When working on a fix or experimenting a new feature you should do it on another branch. See the [Contributing guide](..\..\content\contributing\contributing-workflow.md#suggested-workflow) for specific instructions on the suggested contributing workflow.
+The _develop_ branch is the default working branch. When working on a fix or experimenting a new feature you should do it on another branch. See the [Contributing guide](../../content/contributing/) for specific instructions on the suggested contributing workflow.
 
 If you don't intend to make changes to the nanoBooter and nanoCLR, you can clone [nanoFramework/nf-interpreter](https://github.com/nanoFramework/nf-interpreter) directly from here.
 


### PR DESCRIPTION


## Description
change link for [Contributing guide] as the current one is dead.

## Types of changes
- [x] Improvement (correction, content improvement, typoe fix, formating)
- [ ] New Article (new document for docs website)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)

## Checklist:
- [x] My doc follows the code style of this project.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
