### PR TITLE
Dev container flashing

### DIFF
--- a/content/building/using-dev-container.md
+++ b/content/building/using-dev-container.md
@@ -160,3 +160,17 @@ ARG USERNAME=vscode
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 ```
+
+### Flashing image
+
+Using Docker Desktop from Windows 10 you cannot flash compiled image to your device directly
+because of the limitations of serial port exposal to container. 
+The instructions about "Terminal" -> "Run Task" -> "Flash nanoCRL ..."  available on other
+document pages here wont work.
+
+You can flash the compiled nanoCLR.bin file with [nanoff](../getting-started-guides/getting-started-managed.md#uploading-the-firmware-to-the-board-using-nanofirmwareflasher) tool.
+
+Example:
+```cmd
+nanoff --platform esp32 --serialport COM3 --image nanoCLR.bin --address 0x00010000
+```

--- a/content/building/using-dev-container.md
+++ b/content/building/using-dev-container.md
@@ -171,6 +171,7 @@ document pages here wont work.
 You can flash the compiled nanoCLR.bin file with [nanoff](../getting-started-guides/getting-started-managed.md#uploading-the-firmware-to-the-board-using-nanofirmwareflasher) tool.
 
 Example:
-```cmd
+```console
 nanoff --platform esp32 --serialport COM3 --image nanoCLR.bin --address 0x00010000
 ```
+


### PR DESCRIPTION
Added info about flashing firmware limitations using Dev Container

## Description
At least under Docker Desktop on Windows 10 it isn't possible to use
documented flash tasks of Visual Studio Code IDE.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes/resolves an open issue, please link to the issue here using the template bellow (mind the link as all issues are open in the Home repository, not in this one) -->
- Improves docs.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (correction, content improvement, typoe fix, formating)
- [ ] New Article (new document for docs website)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My doc follows the code style of this project.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
