### PR TITLE
Correct links to Get Started guides

### DIFF
--- a/content/building/build-in-visual-studio.md
+++ b/content/building/build-in-visual-studio.md
@@ -14,9 +14,9 @@ While it is possible to set up a successful build and debug environment using VS
 
 Follow along with one of the guides here:
 
-- [Getting started with *VS Code* and ESP32](https://docs.nanoframework.net/content/building/build-esp32.html)
+- [Getting started with *VS Code* and ESP32](build-esp32.md)
 
-- [Getting started with *VS Code* and STM32](https://docs.nanoframework.net/content/building/build-stm32.html)
+- [Getting started with *VS Code* and STM32](build-stm32.md)
 
 ### Install Visual Studio 2019 Community and workloads
 

--- a/content/building/build-in-visual-studio.md
+++ b/content/building/build-in-visual-studio.md
@@ -14,9 +14,9 @@ While it is possible to set up a successful build and debug environment using VS
 
 Follow along with one of the guides here:
 
-- [Getting started with *VS Code* and ESP32](../getting-started-guides/build-esp32.md)
+- [Getting started with *VS Code* and ESP32](https://docs.nanoframework.net/content/building/build-esp32.html)
 
-- [Getting started with *VS Code* and STM32](../getting-started-guides/build-stm32.md)
+- [Getting started with *VS Code* and STM32](https://docs.nanoframework.net/content/building/build-stm32.html)
 
 ### Install Visual Studio 2019 Community and workloads
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- Inserted path to build-esp32.md and build-stm32.md on the respective links.

## Motivation and Context
- Both existing links " Getting started... " where pointing to the wrong doc.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (correction, content improvement, typo fix, formating)
- [ ] New Article (new document for docs website)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My doc follows the code style of this project.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
