### PR TITLE
Fixing broken Unit Test link

### DIFF
--- a/content/architecture/unit-test.md
+++ b/content/architecture/unit-test.md
@@ -49,4 +49,4 @@ We've been building a Unit Test nanoFramewok project as well in Visual Studio, t
 
 ## Where to look next
 
-The current status and information about usage is available under [Unit Test](/content/unit-test/index.md) main menu entry.
+The current status and information about usage is available under [Unit Test](~/content/unit-test/index.md) main menu entry.


### PR DESCRIPTION
The [Unit Test architecture page ](https://docs.nanoframework.net/content/architecture/unit-test.html) contained a broken link at the bottom.

## Description
According to the [DocFX](https://dotnet.github.io/docfx/tutorial/links_and_cross_references.html#relative-path-vs-absolute-path) docs absolute paths are left as-is (so the .md extension is not replaced with the .html extension). This resulted in a broken link. Adding `~` to reference the doc root path so the .md extension is replaced.

## Motivation and Context
n/a

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (correction, content improvement, typoe fix, formating)
- [ ] New Article (new document for docs website)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My doc follows the code style of this project.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
