### PR TITLE
Add ESP32 Pico Kit help page

### DIFF
--- a/content/reference-targets/esp32-pico-kit.md
+++ b/content/reference-targets/esp32-pico-kit.md
@@ -1,0 +1,69 @@
+# Espressif ESP32 Pico Kit
+
+![ESP32-PICO-KIT_1](https://user-images.githubusercontent.com/71982803/132640376-e0adb80c-ca7f-4f91-bece-8ba5cb77d493.png)
+
+[Getting Started Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/hw-reference/esp32/get-started-pico-kit.html)
+
+[Datasheet](https://www.espressif.com/sites/default/files/documentation/esp32-pico-d4_datasheet_en.pdf)
+
+[Schematic](https://dl.espressif.com/dl/schematics/esp32-pico-kit-v4.1_schematic.pdf)
+
+## Connecting and powering the board
+
+There is only one USB port on the board. It is used to flash and debug the board, and also powers it.
+
+## Installing drivers
+
+ESP32 Pico is acceessed through a Silicon Labs CP210x USB-to-serial adapter chip. Sometimes Windows installs drivers automatically. If not, download and [install them from here](https://www.silabs.com/documents/public/software/CP210x_Universal_Windows_Driver.zip). If everything goes right, ESP32 Pico Kit will present itself as new COM port:
+
+![image](https://user-images.githubusercontent.com/71982803/132641362-eaf39b75-b619-4a42-aadf-7211890d03d5.png)
+
+## Flashing initial nanoFramework firmware
+
+Before you can code in C#, nanoFramework runtime has to be flashed in. This is done by `nanoff` utility, which you installed in the Getting Started guide. Replace "COMx" with the actual port of your system ("COM4" in the screenshot above) and run this command in the Command Prompt:
+
+`nanoff --target ESP32_PICO --serialport COMx --update`
+
+This command will download the latest stable FW revision, detect the the board and flash it. During the process, you may be asked to click BOOT button on the board, so pay attention to the console output.
+
+You are now ready to upload C# programs.
+
+## User LEDs and buttons
+
+The are no user-controllable LEDs on the board, unfortunately. You may use BOOT button, though.
+
+|Marking|MCU port&pin|nF pin number|Alternative function|
+|---|---|---|---|
+|BOOT|IO0|0|-|
+
+## Headers pinout
+
+Markings are different on top and bottom of the board. Tables below references markings that are on the bottom.
+
+|Marking|MCU port&pin|nF pin number|Alternative function|Note|
+|---|---|---|---|---|
+|F_SD1|-|-|-|Connected to internal flash. Do not use.|
+|F_SD3|-|-|-|Connected to internal flash. Do not use.|
+|F_CLK|-|-|-|Connected to internal flash. Do not use.|
+|IO21|GPIO21|21|-||
+|IO22|GPIO22|22|-||
+|IO19|GPIO19|19|-||
+|IO23|GPIO23|23|-||
+|IO18|GPIO18|18|-||
+|IO5|GPIO5|5|-||
+|IO10|GPIO10|10|-||
+|IO9|GPIO9|9|-||
+|RXD0|GPIO3|3|-|Connected to USB-serial bridge. Do not use.|
+|TXD0|GPIO1|1|-|Connected to USB-serial bridge. Do not use.|
+|IO35|-|-|-|Input-only|
+|IO34|-|-|-|Input-only|
+|IO38|GPIO38|38|-|Input-only|
+|IO37|GPIO37|37|-|Input-only|
+|EN|CHIP_PU|-|-||
+|GND|-|-|-||
+|3V3|-|-||
+
+
+|IO|GPIO||-|
+
+

--- a/content/reference-targets/esp32-pico-kit.md
+++ b/content/reference-targets/esp32-pico-kit.md
@@ -55,10 +55,10 @@ Markings are different on top and bottom of the board. Tables below references m
 |IO9|GPIO9|9|-||
 |RXD0|GPIO3|3|-|Connected to USB-serial bridge. Do not use.|
 |TXD0|GPIO1|1|-|Connected to USB-serial bridge. Do not use.|
-|IO35|-|-|-|Input-only|
-|IO34|-|-|-|Input-only|
-|IO38|GPIO38|38|-|Input-only|
-|IO37|GPIO37|37|-|Input-only|
+|IO35|-|-|Analog channel 7|Input-only|
+|IO34|-|-|Analog channel 6|Input-only|
+|IO38|GPIO38|38|Analog channel 2|Input-only|
+|IO37|GPIO37|37|Analog channel 1|Input-only|
 |EN|CHIP_PU|-|-||
 |GND|-|-|-||
 |3V3|-|-||
@@ -68,20 +68,20 @@ Markings are different on top and bottom of the board. Tables below references m
 |F_CS|-|-|-|Connected to internal flash. Do not use.|
 |F_SD0|-|-|-|Connected to internal flash. Do not use.|
 |F_SD2|-|-|-|Connected to internal flash. Do not use.|
-|SVP|GPIO36|36?|-|Input-only|
-|SVN|GPIO39|39?|-|Input-only|
-|IO25|GPIO25|25|-||
-|IO26|GPIO26|26|-||
-|IO32|?|?|-||
-|IO33|?|?|-||
-|IO27|GPIO27|27|-||
-|IO14|?||-||
-|IO12|?||-||
-|IO13|?||-||
-|IO15|?||-||
-|IO2|?||-||
-|IO4|?||-||
-|IO0|?||-||
+|SVP|SENSOR_VP|-|Analog channel 8|Input-only|
+|SVN|SENSOR_VN|-|Analog channel 9|Input-only|
+|IO25|GPIO25|25|Analog channel 18||
+|IO26|GPIO26|26|Analog channel 19||
+|IO32|?|?|Analog channel 4||
+|IO33|?|?|Analog channel 5||
+|IO27|GPIO27|27|Analog channel 17||
+|IO14|?||Analog channel 16||
+|IO12|?||Analog channel 15||
+|IO13|?||Analog channel 14||
+|IO15|?||Analog channel 13||
+|IO2|?||Analog channel 12||
+|IO4|?||Analog channel 10||
+|IO0|?||Analog channel 11||
 |3V3|-|-||
 |GND|-|-|-||
 |5V|-|-|-||

--- a/content/reference-targets/esp32-pico-kit.md
+++ b/content/reference-targets/esp32-pico-kit.md
@@ -51,8 +51,8 @@ Markings are different on top and bottom of the board. Tables below references m
 |IO23|GPIO23|23|-||
 |IO18|GPIO18|18|-||
 |IO5|GPIO5|5|-||
-|IO10|GPIO10|10|-||
-|IO9|GPIO9|9|-||
+|IO10|GPIO10|10|-|GPO no open GPI no open|
+|IO9|GPIO9|9|-|GPO no open GPI no open|
 |RXD0|GPIO3|3|-|Connected to USB-serial bridge. Do not use.|
 |TXD0|GPIO1|1|-|Connected to USB-serial bridge. Do not use.|
 |IO35|-|-|Analog channel 7|Input-only|
@@ -70,18 +70,18 @@ Markings are different on top and bottom of the board. Tables below references m
 |F_SD2|-|-|-|Connected to internal flash. Do not use.|
 |SVP|SENSOR_VP|-|Analog channel 8|Input-only|
 |SVN|SENSOR_VN|-|Analog channel 9|Input-only|
-|IO25|GPIO25|25|Analog channel 18||
-|IO26|GPIO26|26|Analog channel 19||
-|IO32|?|?|Analog channel 4||
-|IO33|?|?|Analog channel 5||
-|IO27|GPIO27|27|Analog channel 17||
-|IO14|?||Analog channel 16||
-|IO12|?||Analog channel 15||
-|IO13|?||Analog channel 14||
-|IO15|?||Analog channel 13||
-|IO2|?||Analog channel 12||
-|IO4|?||Analog channel 10||
-|IO0|?||Analog channel 11||
+|IO25|GPIO25|25|Analog channel 18|ADC no open|
+|IO26|GPIO26|26|Analog channel 19|ADC no open|
+|IO32|GPIO32?|32|Analog channel 4||
+|IO33|GPIO33?|33|Analog channel 5||
+|IO27|GPIO27|27|Analog channel 17|ADC no open|
+|IO14|?||Analog channel 16|ADC no open|
+|IO12|?||Analog channel 15|ADC no open|
+|IO13|?||Analog channel 14|ADC no open|
+|IO15|?||Analog channel 13|ADC no open|
+|IO2|?||Analog channel 12|ADC no open|
+|IO4|?||Analog channel 10|ADC no open|
+|IO0|?||Analog channel 11|ADC no open|
 |3V3|-|-||
 |GND|-|-|-||
 |5V|-|-|-||

--- a/content/reference-targets/esp32-pico-kit.md
+++ b/content/reference-targets/esp32-pico-kit.md
@@ -63,7 +63,31 @@ Markings are different on top and bottom of the board. Tables below references m
 |GND|-|-|-||
 |3V3|-|-||
 
+|Marking|MCU port&pin|nF pin number|Alternative function|Note|
+|---|---|---|---|---|
+|F_CS|-|-|-|Connected to internal flash. Do not use.|
+|F_SD0|-|-|-|Connected to internal flash. Do not use.|
+|F_SD2|-|-|-|Connected to internal flash. Do not use.|
+|SVP|GPIO36|36?|-|Input-only|
+|SVN|GPIO39|39?|-|Input-only|
+|IO25|GPIO25|25|-||
+|IO26|GPIO26|26|-||
+|IO32|?|?|-||
+|IO33|?|?|-||
+|IO27|GPIO27|27|-||
+|IO14|?||-||
+|IO12|?||-||
+|IO13|?||-||
+|IO15|?||-||
+|IO2|?||-||
+|IO4|?||-||
+|IO0|?||-||
+|3V3|-|-||
+|GND|-|-|-||
+|5V|-|-|-||
 
-|IO|GPIO||-|
+## Firmware images (ready to deploy)
 
-
+| Stable | Preview |
+|---|---|
+| [![Latest Version @ Cloudsmith](https://api-prd.cloudsmith.io/v1/badges/version/net-nanoframework/nanoframework-images/raw/ESP32_PICO/latest/x/?render=true)](https://cloudsmith.io/~net-nanoframework/repos/nanoframework-images/packages/detail/raw/ESP32_PICO/latest/) | [![Latest Version @ Cloudsmith](https://api-prd.cloudsmith.io/v1/badges/version/net-nanoframework/nanoframework-images-dev/raw/ESP32_PICO/latest/x/?render=true)](https://cloudsmith.io/~net-nanoframework/repos/nanoframework-images-dev/packages/detail/raw/ESP32_PICO/latest/) |

--- a/content/reference-targets/index.md
+++ b/content/reference-targets/index.md
@@ -6,6 +6,7 @@ We provide ready build firmware images for several reference target boards. Thes
 
 - [ESP32 WROOM-32](esp32-wroom-32.md)
 - [ESP WROVER-KIT](esp32-wroom-32.md)
+- [ESP32 Pico Kit](esp32-pico-kit.md)
 
 ## OrgPal boards
 


### PR DESCRIPTION

## Description
Adding a dedicated reference target page for ESP32 Pico with some useful information.

## Motivation and Context
The page was completely missing.

## Types of changes
- [ ] Improvement (correction, content improvement, typoe fix, formating)
- [x] New Article (new document for docs website)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)

## Checklist:
- [x] My doc follows the code style of this project.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
