### PR TITLE
Update cxx-coding-style.md to auto format on save

### DIFF
--- a/content/contributing/cxx-coding-style.md
+++ b/content/contributing/cxx-coding-style.md
@@ -25,21 +25,23 @@ Just remember the following: add that setting, the path that you've copied befor
 After following the above steps successfully you can now right click on any C, C++ or H file and hit 'Format Document'. The VS Code extension will take care that the document is properly formatted according to the coding style guidelines.
 
 When you have the extension installed, you can request VS Code to automatically format a file on save by adding the following to your vscode settings.json file:
-```
+```json
 {
     "editor.formatOnSave": true
 }
 ```
-WARNING: you need to avoid automatic formating on 3rd party .h files as the foramatting can introduce many changes that add no value and make it very difficult to subsequintly compare the .h file with the orginal or with a template file when the external 3rd party software is updated. 
+>**WARNING**: you need to avoid automatic formating on 3rd party .h files as the foramatting can introduce many changes that add no value and make it very difficult to subsequintly compare the .h file with the orginal or with a template file when the external 3rd party software is updated.
 
 You can turn clang auto format 'off' and 'on' around code you don't what reformatted.
 
 Typically at the top of the file below the Copright notice turn off clang-formating with:
-```
+
+```c
 // clang-format off
 ```
 and  at the end of the file remember to turn it back on with: 
-```
+
+```c
 // clang-format on
 ```
 

--- a/content/contributing/cxx-coding-style.md
+++ b/content/contributing/cxx-coding-style.md
@@ -24,6 +24,25 @@ Just remember the following: add that setting, the path that you've copied befor
 
 After following the above steps successfully you can now right click on any C, C++ or H file and hit 'Format Document'. The VS Code extension will take care that the document is properly formatted according to the coding style guidelines.
 
+When you have the extension installed, you can request VS Code to automatically format a file on save by adding the following to your vscode settings.json file:
+```
+{
+    "editor.formatOnSave": true
+}
+```
+WARNING: you need to avoid automatic formating on 3rd party .h files as the foramatting can introduce many changes that add no value and make it very difficult to subsequintly compare the .h file with the orginal or with a template file when the external 3rd party software is updated. 
+
+You can turn clang auto format 'off' and 'on' around code you don't what reformatted.
+
+Typically at the top of the file below the Copright notice turn off clang-formating with:
+```
+// clang-format off
+```
+and  at the end of the file remember to turn it back on with: 
+```
+// clang-format on
+```
+
 ## Using Visual Studio
 
 If you are using Visual Studio we suggest that you install the [ClangFormat extension](https://marketplace.visualstudio.com/items?itemName=LLVMExtensions.ClangFormat).


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add directions on how to enable clang auto format on file save in VS Code

## Motivation and Context
Helps maintain coding style by formatting documents as they are edited and saved to always follow coding standard, unless explicitly turned off. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (correction, content improvement, typoe fix, formating)
- [ ] New Article (new document for docs website)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My doc follows the code style of this project.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
