### PR TITLE
Updated command for flashing custom image to target

### DIFF
--- a/content/building/using-dev-container.md
+++ b/content/building/using-dev-container.md
@@ -191,5 +191,5 @@ You can flash the compiled nanoCLR.bin file with [nanoff](../getting-started-gui
 Example:
 
 ```console
-nanoff --platform esp32 --serialport COM3 --image nanoCLR.bin --address 0x00010000
+nanoff --deploy --platform esp32 --serialport COM3 --image nanoCLR.bin --address 0x00010000
 ```

--- a/content/building/using-dev-container.md
+++ b/content/building/using-dev-container.md
@@ -191,5 +191,5 @@ You can flash the compiled nanoCLR.bin file with [nanoff](../getting-started-gui
 Example:
 
 ```console
-nanoff --deploy --platform esp32 --serialport COM3 --image nanoCLR.bin --address 0x00010000
+nanoff --update --platform esp32 --serialport COM3 --clrfile nanoCLR.bin
 ```


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The command was missing previously missing, so that the nanoff tool just displayed the information about the board. From what I could gather from the documentation, `--deploy` seems to be the correct command.

## Motivation and Context
This helps newbies (like myself) to correctly flash custom firmwares.

## Types of changes
- [X] Improvement (correction, content improvement, typo fix, formatting)
- [ ] New Article (new document for docs website)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My doc follows the code style of this project.
- [X] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
