### PR TITLE
Describing how to open the dev container manually if the prompt does not show

### DIFF
--- a/content/building/using-dev-container.md
+++ b/content/building/using-dev-container.md
@@ -38,13 +38,15 @@ Go to the file `.devcontainer/devcontainer.json` and choose the container you wa
 > Note: as a beginner, we recommend you to use the pre built containers. If you are familiar with containers and need to adjust resources in them, then use the one which you can build yourself. Use the one in the `./sources` subdirectory. So the file name will be for example `./source/Dockerfile.All` to use the container containing everything and build it from the source.
 > Error: if you get error message like "Bad Cmake executable "". Is it installed or settings contain the correct path (cmake.cmakePath)?  The solution: uninstall the Cmake and Cmake tool from Visual Studio Code and restart Visual Studio Code.  
 
-- **Step 9**: Once prompted or thru the menu, open the dev container.
+- **Step 9**: Once prompted, open the dev container.
 
-This is illustrating how to do this:
+  This is illustrating how to do this:
 
-![remote container animation](https://microsoft.github.io/vscode-remote-release/images/remote-containers-readme.gif)
+  ![remote container animation](https://microsoft.github.io/vscode-remote-release/images/remote-containers-readme.gif)
 
-> note: in our case, the dev container is called `nanoFramework`.
+  > note: in our case, the dev container is called `nanoFramework`.
+
+  If VS Code does not show the prompt, you can press F1 to show all commands. In this list, you can select the item "Remote-Containers: Open Folder in Container..." to open the dev container manually. This option will require you to select the folder through the folder selection dialog.
 
 - **Step 10**: At that point, like in the previous illustration, when clicking on the logs, you should see activities. Be patient. Yes, super patient.
 - **Step 11**: We told you to be patient, go for a tea, or a coffee. This part is resource intensive, most of your memory and processor will be used.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
For me, the prompt did not open automatically in VS Code. The PR adds a description on how to open the dev container manually.

## Motivation and Context
Helps users to open the dev container, if they previously have not used the functionality.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Improvement (correction, content improvement, typo fix, formatting)
- [ ] New Article (new document for docs website)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My doc follows the code style of this project.
- [X] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
