### PR TITLE
Update simplifications-and-trade-offs

### DIFF
--- a/content/architecture/simplifications-and-trade-offs.md
+++ b/content/architecture/simplifications-and-trade-offs.md
@@ -18,6 +18,7 @@ Notes:
 
 - These could be made available, at the expense of increasing the PE size.
 - For `Enum.IsDefined()` you can always use a switch instruction in your code to create something similar depending on your use case.
+- An enum value's ToString() will return the numerical value as a string, not the enum name as is the case for other platforms. 
 
 ## Multidimensional arrays
 

--- a/content/architecture/simplifications-and-trade-offs.md
+++ b/content/architecture/simplifications-and-trade-offs.md
@@ -18,7 +18,7 @@ Notes:
 
 - These could be made available, at the expense of increasing the PE size.
 - For `Enum.IsDefined()` you can always use a switch instruction in your code to create something similar depending on your use case.
-- An enum value's ToString() will return the numerical value as a string, not the enum name as is the case for other platforms. 
+- An enum value's ToString() will return the numerical value as a string, not the enum name as is the case for other platforms.
 
 ## Multidimensional arrays
 


### PR DESCRIPTION
Document enum value.ToString() differences to standard behavior

## Description
Lack of enum value ToString() can be a gotcha in existing codebase that uses this to log configuration. So document this explicitly.

## Motivation and Context
Helps users avoid surprises when adopting nF.

## Types of changes
- [x] Improvement (correction, content improvement, typo fix, formatting)
- [ ] New Article (new document for docs website)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)

## Checklist:
- [x] My doc follows the code style of this project.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.