### PR TITLE
Work CI-CD

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,8 +5,13 @@ trigger:
   paths:
     exclude: 
       - README.md
-      - LICENSE.md
+      - LICENSE
+      - LICENSE-CODE
       - .gitignore
+      - .markdownlint.json
+      - docfx.json
+      - CNAME
+      - toc.yml
 
 # PR always trigger build   
 pr:
@@ -20,11 +25,10 @@ resources:
       endpoint: nanoframework
 
 pool:
-  vmImage: 'windows-2019'
+  vmImage: 'windows-latest'
 
 variables:
   DOTNET_NOLOGO: true
-  solution: '**/*.sln'
   buildPlatform: 'Any CPU'
   buildConfiguration: 'Release'
 
@@ -33,6 +37,7 @@ steps:
 # need this here in order to persist GitHub credentials
 - checkout: self
   persistCredentials: true
+  fetchDepth: 1
 
 # setup GitHub credentials and prefs
 - script: |
@@ -55,7 +60,7 @@ steps:
         # get PR message
         $prUrl = "https://api.github.com/repos/$env:Build_Repository_Name/pulls/$env:System_PullRequest_PullRequestNumber"
 
-        $commit = Invoke-RestMethod -Uri $prUrl -ContentType "application/json" -Method GET
+        $commit = Invoke-RestMethod -Uri $prUrl -ContentType "application/json" -Method GET -Headers @{Authorization = "Bearer $(GitHubToken)"}
 
         $commitMessage = $commit.body
     }
@@ -80,7 +85,7 @@ steps:
     if($env:System_PullRequest_PullRequestId -ne $null)
     {
         # get files changed in PR
-        $commit = Invoke-RestMethod -Uri "https://api.github.com/repos/$env:Build_Repository_Name/pulls/$env:System_PullRequest_PullRequestNumber/files" -Header @{"Authorization"="$auth"} -ContentType "application/json" -Method GET
+        $commit = Invoke-RestMethod -Uri "https://api.github.com/repos/$env:Build_Repository_Name/pulls/$env:System_PullRequest_PullRequestNumber/files" -ContentType "application/json" -Method GET -Headers @{Authorization = "Bearer $(GitHubToken)"}
 
         # filter removed files              
         $files = $commit.where{$_.status -ne 'removed'}
@@ -121,114 +126,117 @@ steps:
   displayName: Get commit details
 
 # clone class libs repos
-# fetch only the last 100 commits to be (reasonaly) sure that we have the history up to the last tag
+# fetch only the last 100 commits (if available) to be (reasonaly) sure that we have the history up to the last tag
 - powershell: |
-      git clone https://github.com/nanoframework/CoreLibrary.git --recursive --depth 100 -b main CoreLibrary 
+      git clone https://github.com/nanoframework/CoreLibrary.git --recursive --depth 100 -b main libs/CoreLibrary 
 
-      git clone https://github.com/nanoframework/nanoFramework.Device.Can.git --depth 100 -b main nanoFramework.Device.Can 
+      git clone https://github.com/nanoframework/nanoFramework.Device.Can.git --depth 100 -b main libs/nanoFramework.Device.Can 
 
-      git clone https://github.com/nanoframework/nanoFramework.Device.OneWire.git --depth 100 -b main nanoFramework.Device.OneWire 
+      git clone https://github.com/nanoframework/nanoFramework.Device.OneWire.git --depth 100 -b main libs/nanoFramework.Device.OneWire 
 
-      git clone https://github.com/nanoframework/nanoFramework.Runtime.Events.git --depth 100 -b main nanoFramework.Runtime.Events 
+      git clone https://github.com/nanoframework/nanoFramework.Runtime.Events.git --depth 100 -b main libs/nanoFramework.Runtime.Events 
 
-      git clone https://github.com/nanoframework/nanoFramework.Runtime.Native.git --depth 100 -b main nanoFramework.Runtime.Native 
+      git clone https://github.com/nanoframework/nanoFramework.Runtime.Native.git --depth 100 -b main libs/nanoFramework.Runtime.Native 
 
-      git clone https://github.com/nanoframework/nanoFramework.WebServer -b main nanoFramework.WebServer 
+      git clone https://github.com/nanoframework/nanoFramework.WebServer -b main libs/nanoFramework.WebServer 
 
-      git clone https://github.com/nanoframework/nanoFramework.DependencyInjection -b main nanoFramework.DependencyInjection 
+      git clone https://github.com/nanoframework/nanoFramework.DependencyInjection -b main libs/nanoFramework.DependencyInjection 
 
-      git clone https://github.com/nanoframework/nanoFramework.Hosting -b main nanoFramework.Hosting 
+      git clone https://github.com/nanoframework/nanoFramework.Hosting -b main libs/nanoFramework.Hosting 
 
-      git clone https://github.com/nanoframework/System.Device.Dac.git --depth 100 -b main System.Device.Dac
+      git clone https://github.com/nanoframework/System.Device.Dac.git --depth 100 -b main libs/System.Device.Dac
 
-      git clone https://github.com/nanoframework/System.Device.Gpio.git --depth 100 -b main System.Device.Gpio 
+      git clone https://github.com/nanoframework/System.Device.Gpio.git --depth 100 -b main libs/System.Device.Gpio 
 
-      git clone https://github.com/nanoframework/Windows.Devices.Gpio.git --depth 100 -b main Windows.Devices.Gpio 
+      # removing as this one is deprecated and is not building in VS2022
+      # git clone https://github.com/nanoframework/Windows.Devices.Gpio.git --depth 100 -b main libs/Windows.Devices.Gpio 
 
-      git clone https://github.com/nanoframework/Windows.Devices.I2c.git --depth 100 -b main Windows.Devices.I2c 
+      # removing as this one is deprecated and is not building in VS2022
+      # git clone https://github.com/nanoframework/Windows.Devices.I2c.git --depth 100 -b main libs/Windows.Devices.I2c 
 
-      git clone https://github.com/nanoframework/System.Device.I2c.git --depth 100 -b main System.Device.I2c
+      git clone https://github.com/nanoframework/System.Device.I2c.git --depth 100 -b main libs/System.Device.I2c
 
-      git clone https://github.com/nanoframework/System.Device.I2s.git --depth 100 -b main System.Device.I2s
+      git clone https://github.com/nanoframework/System.Device.I2s.git --depth 100 -b main libs/System.Device.I2s
 
-      git clone https://github.com/nanoframework/System.IO.FileSystem.git --depth 100 -b main System.IO.FileSystem
+      git clone https://github.com/nanoframework/System.IO.FileSystem.git --depth 100 -b main libs/System.IO.FileSystem
 
-      git clone https://github.com/nanoframework/System.IO.Streams.git --depth 100 -b main System.IO.Streams
+      git clone https://github.com/nanoframework/System.IO.Streams.git --depth 100 -b main libs/System.IO.Streams
 
-      git clone https://github.com/nanoframework/System.Runtime.Serialization.git --depth 100 -b main System.Runtime.Serialization
+      git clone https://github.com/nanoframework/System.Runtime.Serialization.git --depth 100 -b main libs/System.Runtime.Serialization
 
-      git clone https://github.com/nanoframework/Windows.Devices.Pwm.git --depth 100 -b main Windows.Devices.Pwm 
+      # removing as this one is deprecated and is not building in VS2022
+      # git clone https://github.com/nanoframework/Windows.Devices.Pwm.git --depth 100 -b main libs/Windows.Devices.Pwm 
 
-      git clone https://github.com/nanoframework/System.Device.Pwm.git --depth 100 -b main System.Device.Pwm
+      git clone https://github.com/nanoframework/System.Device.Pwm.git --depth 100 -b main libs/System.Device.Pwm
 
-      git clone https://github.com/nanoframework/Windows.Devices.SerialCommunication.git -b main Windows.Devices.SerialCommunication 
+      # removing as this one is deprecated and is not building in VS2022
+      # git clone https://github.com/nanoframework/Windows.Devices.SerialCommunication.git -b main libs/Windows.Devices.SerialCommunication 
 
-      git clone https://github.com/nanoframework/Windows.Devices.Spi.git --depth 100 -b main Windows.Devices.Spi 
+      # removing as this one is deprecated and is not building in VS2022
+      # git clone https://github.com/nanoframework/Windows.Devices.Spi.git --depth 100 -b main libs/Windows.Devices.Spi 
 
-      git clone https://github.com/nanoframework/System.Device.Spi.git --depth 100 -b main System.Device.Spi
+      git clone https://github.com/nanoframework/System.Device.Spi.git --depth 100 -b main libs/System.Device.Spi
 
-      git clone https://github.com/nanoframework/Windows.Storage.git --depth 100 -b main Windows.Storage 
+      git clone https://github.com/nanoframework/Windows.Storage.git --depth 100 -b main libs/Windows.Storage 
 
-      git clone https://github.com/nanoframework/Windows.Storage.Streams.git --depth 100 -b main Windows.Storage.Streams 
+      git clone https://github.com/nanoframework/Windows.Storage.Streams.git --depth 100 -b main libs/Windows.Storage.Streams 
 
-      git clone https://github.com/nanoframework/Windows.Devices.Adc.git --depth 100 -b main Windows.Devices.Adc 
+      # removing as this one is deprecated and is not building in VS2022
+      # git clone https://github.com/nanoframework/Windows.Devices.Adc.git --depth 100 -b main libs/Windows.Devices.Adc 
       
-      git clone https://github.com/nanoframework/System.Device.Adc.git --depth 100 -b main System.Device.Adc 
+      git clone https://github.com/nanoframework/System.Device.Adc.git --depth 100 -b main libs/System.Device.Adc 
 
-      git clone https://github.com/nanoframework/System.Device.WiFi.git --depth 100 -b main System.Device.WiFi 
+      git clone https://github.com/nanoframework/System.Device.WiFi.git --depth 100 -b main libs/System.Device.WiFi 
 
-      git clone https://github.com/nanoframework/nanoFramework.Benchmark -b main nanoFramework.Benchmark 
+      git clone https://github.com/nanoframework/nanoFramework.Benchmark -b main libs/nanoFramework.Benchmark 
 
-      git clone https://github.com/nanoframework/nanoFramework.Graphics -b main nanoFramework.Graphics 
+      git clone https://github.com/nanoframework/nanoFramework.Graphics -b main libs/nanoFramework.Graphics 
 
-      git clone https://github.com/nanoframework/nanoFramework.Hardware.Esp32 -b main nanoFramework.Hardware.Esp32
+      git clone https://github.com/nanoframework/nanoFramework.Hardware.Esp32 -b main libs/nanoFramework.Hardware.Esp32
 
-      git clone https://github.com/nanoframework/nanoFramework.Hardware.Esp32.Rmt -b main nanoFramework.Hardware.Esp32.Rmt
+      git clone https://github.com/nanoframework/nanoFramework.Hardware.Esp32.Rmt -b main libs/nanoFramework.Hardware.Esp32.Rmt
 
-      git clone https://github.com/nanoframework/nanoFramework.Json -b main nanoFramework.Json
+      git clone https://github.com/nanoframework/nanoFramework.Json -b main libs/nanoFramework.Json
 
-      git clone https://github.com/nanoframework/nanoFramework.Hardware.Stm32 -b main nanoFramework.Hardware.Stm32
+      git clone https://github.com/nanoframework/nanoFramework.Hardware.Stm32 -b main libs/nanoFramework.Hardware.Stm32
 
-      git clone https://github.com/nanoframework/nanoFramework.ResourceManager -b main nanoFramework.ResourceManager
+      git clone https://github.com/nanoframework/nanoFramework.ResourceManager -b main libs/nanoFramework.ResourceManager
 
-      git clone https://github.com/nanoframework/nanoFramework.Networking.Sntp -b main nanoFramework.Networking.Sntp 
+      git clone https://github.com/nanoframework/nanoFramework.Networking.Sntp -b main libs/nanoFramework.Networking.Sntp 
 
-      git clone https://github.com/nanoframework/System.Collections -b main System.Collections 
+      git clone https://github.com/nanoframework/System.Collections -b main libs/System.Collections 
 
-      git clone https://github.com/nanoframework/System.Text -b main System.Text 
+      git clone https://github.com/nanoframework/System.Text -b main libs/System.Text 
 
-      git clone https://github.com/nanoframework/System.Net -b main System.Net 
+      git clone https://github.com/nanoframework/System.Net -b main libs/System.Net 
 
-      git clone https://github.com/nanoframework/System.Net.Http -b main System.Net.Http 
+      git clone https://github.com/nanoframework/System.Net.Http -b main libs/System.Net.Http 
 
-      git clone https://github.com/nanoframework/System.Net.WebSockets -b main System.Net.WebSockets 
+      git clone https://github.com/nanoframework/System.Net.WebSockets -b main libs/System.Net.WebSockets 
 
-      git clone https://github.com/nanoframework/nanoFramework.TI.EasyLink -b main nanoFramework.TI.EasyLink
+      git clone https://github.com/nanoframework/nanoFramework.TI.EasyLink -b main libs/nanoFramework.TI.EasyLink
 
-      git clone https://github.com/nanoframework/nanoFramework.Hardware.TI -b main nanoFramework.Hardware.TI
+      git clone https://github.com/nanoframework/nanoFramework.Hardware.TI -b main libs/nanoFramework.Hardware.TI
 
-      git clone https://github.com/nanoframework/System.Math -b main System.Math 
+      git clone https://github.com/nanoframework/System.Math -b main libs/System.Math 
 
-      git clone https://github.com/nanoframework/nanoFramework.Logging -b main nanoFramework.Logging
+      git clone https://github.com/nanoframework/nanoFramework.Logging -b main libs/nanoFramework.Logging
 
-      git clone https://github.com/nanoframework/System.IO.Ports.git --depth 100 -b main System.IO.Ports
+      git clone https://github.com/nanoframework/System.IO.Ports.git --depth 100 -b main libs/System.IO.Ports
 
-      git clone https://github.com/nanoframework/nanoFramework.m2mqtt.git --depth 100 -b main nanoFramework.M2Mqtt
+      git clone https://github.com/nanoframework/nanoFramework.m2mqtt.git --depth 100 -b main libs/nanoFramework.M2Mqtt
 
-      git clone https://github.com/nanoframework/System.Text.RegularExpressions.git --depth 100 -b main System.Text.RegularExpressions
+      git clone https://github.com/nanoframework/System.Text.RegularExpressions.git --depth 100 -b main libs/System.Text.RegularExpressions
 
-      git clone https://github.com/nanoframework/nanoFramework.Azure.Devices.git -b main nanoFramework.Azure.Devices
+      git clone https://github.com/nanoframework/nanoFramework.Azure.Devices.git -b main libs/nanoFramework.Azure.Devices
       
-      git clone https://github.com/nanoframework/nanoFramework.Aws.IoTCore.Devices.git -b main nanoFramework.Aws.IoTCore.Devices
+      git clone https://github.com/nanoframework/nanoFramework.Aws.IoTCore.Devices.git -b main libs/nanoFramework.Aws.IoTCore.Devices
 
-      git clone https://github.com/nanoframework/nanoFramework.SignalR.Client.git -b main nanoFramework.SignalR.Client      
+      git clone https://github.com/nanoframework/nanoFramework.SignalR.Client.git -b main libs/nanoFramework.SignalR.Client      
 
-      git clone https://github.com/nanoframework/System.Net.Sockets.TcpClient.git -b main System.Net.Sockets.TcpClient
+      git clone https://github.com/nanoframework/System.Net.Sockets.TcpClient.git -b main libs/System.Net.Sockets.TcpClient
 
-      git clone https://github.com/nanoframework/System.Net.Sockets.UdpClient.git -b main System.Net.Sockets.UdpClient
-
-      git clone https://github.com/nanoframework/nanoFramework.IoT.Device.git -b develop nanoFramework.IoT.Device
-
+      git clone https://github.com/nanoframework/System.Net.Sockets.UdpClient.git -b main libs/System.Net.Sockets.UdpClient
   displayName: Clone repos of class libs
   condition: >-
     or(
@@ -236,6 +244,38 @@ steps:
       contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
       eq(variables['BuildOptions.BUILD_ALL'], 'true')
     )
+
+# clone IoT bindings repo
+- powershell: |
+      git clone https://github.com/nanoframework/nanoFramework.IoT.Device.git -b develop nanoFramework.IoT.Device
+  displayName: Clone IoT binding repo
+  condition: >-
+    and(
+      succeeded(),
+      or(
+        eq(variables['BUILD_ALL'], 'true'),
+        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
+        eq(variables['BuildOptions.BUILD_ALL'], 'true')
+      )
+    )
+
+# Clean all solutions that are not needed to build nor generate documentation
+- task: PowerShell@2
+  displayName: Delete unnecessary solutions
+  condition: >-
+    and(
+      succeeded(),
+      or(
+        eq(variables['BUILD_ALL'], 'true'),
+        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
+        eq(variables['BuildOptions.BUILD_ALL'], 'true')
+      )
+    ) 
+  inputs:
+    targetType: 'inline'
+    script: |
+      Remove-Item -Force libs\CoreLibrary\nanoFramework.TestFramework\nanoFramework.TestAdapter.sln
+      Remove-Item -Force libs\nanoFramework.M2Mqtt\nanoFramework.Mqtt.TestApps.sln
 
 - powershell: choco install docfx-companion-tools -y
   displayName: Install the docfx helpers
@@ -347,859 +387,17 @@ steps:
     key: 'nuget | **/packages.lock.json'
     path: $(UserProfile)/.nuget/packages
 
-# build all libs
-
+# restore all solutions
 - task: NuGetCommand@2
-  displayName: NuGet restore CoreLibrary
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
+  displayName: NuGet restore all class libs
+  retryCountOnTaskFailure: 3
   inputs:
-    restoreSolution: 'CoreLibrary\nanoFramework.CoreLibrary.sln'
-    feedsToUse: config
-    nugetConfigPath: 'CoreLibrary\NuGet.Config'
-
-- task: NuGetCommand@2
-  displayName: NuGet restore nanoFramework.Device.Can
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    restoreSolution: 'nanoFramework.Device.Can\nanoFramework.Device.Can.sln'
-    feedsToUse: config
-    nugetConfigPath: 'nanoFramework.Device.Can\NuGet.Config'
-
-- task: NuGetCommand@2
-  displayName: NuGet restore nanoFramework.Device.OneWire
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    restoreSolution: 'nanoFramework.Device.OneWire\nanoFramework.Device.OneWire.sln'
-    feedsToUse: config
-    nugetConfigPath: 'nanoFramework.Device.OneWire\NuGet.Config'
-
-- task: NuGetCommand@2
-  displayName: NuGet restore nanoFramework.Runtime.Events
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    restoreSolution: 'nanoFramework.Runtime.Events\nanoFramework.Runtime.Events.sln'
-    feedsToUse: config
-    nugetConfigPath: 'nanoFramework.Runtime.Events\NuGet.Config'
-
-- task: NuGetCommand@2
-  displayName: NuGet restore nanoFramework.Runtime.Native
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    restoreSolution: 'nanoFramework.Runtime.Native\nanoFramework.Runtime.Native.sln'
-    feedsToUse: config
-    nugetConfigPath: 'nanoFramework.Runtime.Native\NuGet.Config'
-
-- task: NuGetCommand@2
-  displayName: NuGet restore nanoFramework.WebServer
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    restoreSolution: 'nanoFramework.WebServer\nanoFramework.WebServer.sln'
-    feedsToUse: config
-    nugetConfigPath: 'nanoFramework.WebServer\NuGet.Config'
-
-- task: NuGetCommand@2
-  displayName: NuGet restore nanoFramework.DependencyInjection
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    restoreSolution: 'nanoFramework.DependencyInjection\nanoFramework.DependencyInjection.sln'
-    feedsToUse: config
-    nugetConfigPath: 'nanoFramework.DependencyInjection\NuGet.Config'
-
-- task: NuGetCommand@2
-  displayName: NuGet restore nanoFramework.Hosting
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    restoreSolution: 'nanoFramework.Hosting\nanoFramework.Hosting.sln'
-    feedsToUse: config
-    nugetConfigPath: 'nanoFramework.Hosting\NuGet.Config'
-
-- task: NuGetCommand@2
-  displayName: NuGet restore System.Device.Dac
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    restoreSolution: 'System.Device.Dac\nanoFramework.System.Device.Dac.sln'
-    feedsToUse: config
-    nugetConfigPath: 'System.Device.Dac\NuGet.Config'
-
-- task: NuGetCommand@2
-  displayName: NuGet restore System.Device.Gpio
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    restoreSolution: 'System.Device.Gpio\nanoFramework.System.Device.Gpio.sln'
-    feedsToUse: config
-    nugetConfigPath: 'System.Device.Gpio\NuGet.Config'
-
-- task: NuGetCommand@2
-  displayName: NuGet restore Windows.Devices.Gpio
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    restoreSolution: 'Windows.Devices.Gpio\nanoFramework.Windows.Devices.Gpio.sln'
-    feedsToUse: config
-    nugetConfigPath: 'Windows.Devices.Gpio\NuGet.Config'
-
-- task: NuGetCommand@2
-  displayName: NuGet restore Windows.Devices.I2c
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    restoreSolution: 'Windows.Devices.I2c\nanoFramework.Windows.Devices.I2c.sln'
-    feedsToUse: config
-    nugetConfigPath: 'Windows.Devices.I2c\NuGet.Config'
-
-- task: NuGetCommand@2
-  displayName: NuGet restore System.Device.I2c
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    restoreSolution: 'System.Device.I2c\nanoFramework.System.Device.I2c.sln'
-    feedsToUse: config
-    nugetConfigPath: 'System.Device.I2c\NuGet.Config'
-
-- task: NuGetCommand@2
-  displayName: NuGet restore System.Device.I2s
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    restoreSolution: 'System.Device.I2s\nanoFramework.System.Device.I2s.sln'
-    feedsToUse: config
-    nugetConfigPath: 'System.Device.I2s\NuGet.Config'
-
-- task: NuGetCommand@2
-  displayName: NuGet restore System.IO.FileSystem
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    restoreSolution: 'System.IO.FileSystem\nanoFramework.System.IO.FileSystem.sln'
-    feedsToUse: config
-    nugetConfigPath: 'System.IO.FileSystem\NuGet.Config'
-
-- task: NuGetCommand@2
-  displayName: NuGet restore System.IO.Streams
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    restoreSolution: 'System.IO.Streams\nanoFramework.System.IO.Streams.sln'
-    feedsToUse: config
-    nugetConfigPath: 'System.IO.Streams\NuGet.Config'
-
-- task: NuGetCommand@2
-  displayName: NuGet restore System.Runtime.Serialization
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    restoreSolution: 'System.Runtime.Serialization\nanoFramework.System.Runtime.Serialization.sln'
-    feedsToUse: config
-    nugetConfigPath: 'System.Runtime.Serialization\NuGet.Config'
-
-- task: NuGetCommand@2
-  displayName: NuGet restore Windows.Devices.Pwm
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    restoreSolution: 'Windows.Devices.Pwm\nanoFramework.Windows.Devices.Pwm.sln'
-    feedsToUse: config
-    nugetConfigPath: 'Windows.Devices.Pwm\NuGet.Config'
-
-- task: NuGetCommand@2
-  displayName: NuGet restore System.Device.Pmw
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    restoreSolution: 'System.Device.Pwm\nanoFramework.System.Device.Pwm.sln'
-    feedsToUse: config
-    nugetConfigPath: 'System.Device.Pwm\NuGet.Config'
-
-- task: NuGetCommand@2
-  displayName: NuGet restore Windows.Devices.SerialCommunication
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    restoreSolution: 'Windows.Devices.SerialCommunication\nanoFramework.Windows.Devices.SerialCommunication.sln'
-    feedsToUse: config
-    nugetConfigPath: 'Windows.Devices.SerialCommunication\NuGet.Config'
-
-- task: NuGetCommand@2
-  displayName: NuGet restore Windows.Devices.Spi
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    restoreSolution: 'Windows.Devices.Spi\nanoFramework.Windows.Devices.Spi.sln'
-    feedsToUse: config
-    nugetConfigPath: 'Windows.Devices.Spi\NuGet.Config'
-
-- task: NuGetCommand@2
-  displayName: NuGet restore System.Device.Spi
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    restoreSolution: 'System.Device.Spi\nanoFramework.System.Device.Spi.sln'
-    feedsToUse: config
-    nugetConfigPath: 'System.Device.Spi\NuGet.Config'
-
-- task: NuGetCommand@2
-  displayName: NuGet restore Windows.Storage
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    restoreSolution: 'Windows.Storage\nanoFramework.Windows.Storage.sln'
-    feedsToUse: config
-    nugetConfigPath: 'Windows.Storage\NuGet.Config'
-
-- task: NuGetCommand@2
-  displayName: NuGet restore Windows.Storage.Streams
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    restoreSolution: 'Windows.Storage.Streams\nanoFramework.Windows.Storage.Streams.sln'
-    feedsToUse: config
-    nugetConfigPath: 'Windows.Storage.Streams\NuGet.Config'
-
-- task: NuGetCommand@2
-  displayName: NuGet restore Windows.Devices.Adc
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    restoreSolution: 'Windows.Devices.Adc\nanoFramework.Windows.Devices.Adc.sln'
-    feedsToUse: config
-    nugetConfigPath: 'Windows.Devices.Adc\NuGet.Config'
-    
-- task: NuGetCommand@2
-  displayName: NuGet restore System.Device.Adc
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    restoreSolution: 'System.Device.Adc\nanoFramework.System.Device.Adc.sln'
-    feedsToUse: config
-    nugetConfigPath: 'System.Device.Adc\NuGet.Config'
-
-- task: NuGetCommand@2
-  displayName: NuGet restore System.Device.WiFi
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    restoreSolution: 'System.Device.WiFi\nanoFramework.System.Device.WiFi.sln'
-    feedsToUse: config
-    nugetConfigPath: 'System.Device.WiFi\NuGet.Config'
-
-- task: NuGetCommand@2
-  displayName: NuGet restore nanoFramework.Benchmark
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    restoreSolution: 'nanoFramework.Benchmark\nanoFramework.Benchmark.sln'
-    feedsToUse: config
-    nugetConfigPath: 'nanoFramework.Benchmark\NuGet.Config'
-
-- task: NuGetCommand@2
-  displayName: NuGet restore nanoFramework.Graphics
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    restoreSolution: 'nanoFramework.Graphics\nanoFramework.Graphics.sln'
-    feedsToUse: config
-    nugetConfigPath: 'nanoFramework.Graphics\NuGet.Config'
-
-- task: NuGetCommand@2
-  displayName: NuGet restore nanoFramework.Hardware.Esp32
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    restoreSolution: 'nanoFramework.Hardware.Esp32\nanoFramework.Hardware.Esp32.sln'
-    feedsToUse: config
-    nugetConfigPath: 'nanoFramework.Hardware.Esp32\NuGet.Config'
-
-- task: NuGetCommand@2
-  displayName: NuGet restore nanoFramework.Hardware.Esp32.Rmt
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    restoreSolution: 'nanoFramework.Hardware.Esp32.Rmt\nanoFramework.Hardware.Esp32.Rmt.sln'
-    feedsToUse: config
-    nugetConfigPath: 'nanoFramework.Hardware.Esp32.Rmt\NuGet.Config'
-
-- task: NuGetCommand@2
-  displayName: NuGet restore nanoFramework.Json
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    restoreSolution: 'nanoFramework.Json\nanoFramework.Json.sln'
-    feedsToUse: config
-    nugetConfigPath: 'nanoFramework.Json\NuGet.Config'
-
-- task: NuGetCommand@2
-  displayName: NuGet restore nanoFramework.Hardware.Stm32
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    restoreSolution: 'nanoFramework.Hardware.Stm32\nanoFramework.Hardware.Stm32.sln'
-    feedsToUse: config
-    nugetConfigPath: 'nanoFramework.Hardware.Stm32\NuGet.Config'
-
-- task: NuGetCommand@2
-  displayName: NuGet restore nanoFramework.ResourceManager
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    restoreSolution: 'nanoFramework.ResourceManager\nanoFramework.ResourceManager.sln'
-    feedsToUse: config
-    nugetConfigPath: 'nanoFramework.ResourceManager\NuGet.Config'
-
-- task: NuGetCommand@2
-  displayName: NuGet restore nanoFramework.Networking.Sntp
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    restoreSolution: 'nanoFramework.Networking.Sntp\nanoFramework.Networking.Sntp.sln'
-    feedsToUse: config
-    nugetConfigPath: 'nanoFramework.Networking.Sntp\NuGet.Config'
-
-- task: NuGetCommand@2
-  displayName: NuGet restore System.Collections
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    restoreSolution: 'System.Collections\nanoFramework.System.Collections.sln'
-    feedsToUse: config
-    nugetConfigPath: 'System.Collections\NuGet.Config'
-
-- task: NuGetCommand@2
-  displayName: NuGet restore System.Text
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    restoreSolution: 'System.Text\nanoFramework.System.Text.sln'
-    feedsToUse: config
-    nugetConfigPath: 'System.Text\NuGet.Config'
-
-- task: NuGetCommand@2
-  displayName: NuGet restore System.Net
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    restoreSolution: 'System.Net\nanoFramework.System.Net.sln'
-    feedsToUse: config
-    nugetConfigPath: 'System.Net\NuGet.Config'
-
-- task: NuGetCommand@2
-  displayName: NuGet restore System.Net.Http
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    restoreSolution: 'System.Net.Http\nanoFramework.System.Net.Http.sln'
-    feedsToUse: config
-    nugetConfigPath: 'System.Net.Http\NuGet.Config'
-
-- task: NuGetCommand@2
-  displayName: NuGet restore System.Net.WebSockets
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    restoreSolution: 'System.Net.WebSockets\nanoFramework.System.Net.WebSockets.sln'
-    feedsToUse: config
-    nugetConfigPath: 'System.Net.WebSockets\NuGet.Config'
-
-- task: NuGetCommand@2
-  displayName: NuGet restore nanoFramework.TI.EasyLink
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    restoreSolution: 'nanoFramework.TI.EasyLink\nanoFramework.TI.EasyLink.sln'
-    feedsToUse: config
-    nugetConfigPath: 'nanoFramework.TI.EasyLink\NuGet.Config'
-
-- task: NuGetCommand@2
-  displayName: NuGet restore nanoFramework.Hardware.TI
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    restoreSolution: 'nanoFramework.Hardware.TI\nanoFramework.Hardware.TI.sln'
-    feedsToUse: config
-    nugetConfigPath: 'nanoFramework.Hardware.TI\NuGet.Config'
-
-- task: NuGetCommand@2
-  displayName: NuGet restore System.Math
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    restoreSolution: 'System.Math\nanoFramework.System.Math.sln'
-    feedsToUse: config
-    nugetConfigPath: 'System.Math\NuGet.Config'
-
-- task: NuGetCommand@2
-  displayName: NuGet restore nanoFramework.Logging
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    restoreSolution: 'nanoFramework.Logging\nanoFramework.Logging.sln'
-    feedsToUse: config
-    nugetConfigPath: 'nanoFramework.Logging\NuGet.Config'
-  
-- task: NuGetCommand@2
-  displayName: NuGet restore System.IO.Ports
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    restoreSolution: 'System.IO.Ports\nanoFramework.System.IO.Ports.sln'
-    feedsToUse: config
-    nugetConfigPath: 'System.IO.Ports\NuGet.Config'
-
-- task: NuGetCommand@2
-  displayName: NuGet restore nanoFramework.M2Mqtt
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    restoreSolution: 'nanoFramework.M2Mqtt\nanoFramework.M2Mqtt.sln'
-    feedsToUse: config
-    nugetConfigPath: 'nanoFramework.M2Mqtt\NuGet.Config'
-      
-- task: NuGetCommand@2
-  displayName: NuGet restore System.Text.RegularExpressions
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    restoreSolution: 'System.Text.RegularExpressions\nanoFramework.System.Text.RegularExpressions.sln'
-    feedsToUse: config
-    nugetConfigPath: 'System.Text.RegularExpressions\NuGet.Config'
-
-- task: NuGetCommand@2
-  displayName: NuGet restore nanoFramework.Azure.Devices
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    restoreSolution: 'nanoFramework.Azure.Devices\nanoFramework.Azure.Devices.Client.sln'
-    feedsToUse: config
-    nugetConfigPath: 'nanoFramework.Azure.Devices\NuGet.Config'
-    
-- task: NuGetCommand@2
-  displayName: NuGet restore nanoFramework.Aws.IoTCore.Devices
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    restoreSolution: 'nanoFramework.Aws.IoTCore.Devices\nanoFramework.Aws.IoTCore.Devices.sln'
-    feedsToUse: config
-    nugetConfigPath: 'nanoFramework.Aws.IoTCore.Devices\NuGet.Config'
-
-- task: NuGetCommand@2
-  displayName: NuGet restore nanoFramework.SignalR.Client
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    restoreSolution: 'nanoFramework.SignalR.Client\nanoFramework.SignalR.Client.sln'
-    feedsToUse: config
-    nugetConfigPath: 'nanoFramework.SignalR.Client\NuGet.Config'
-
-- task: NuGetCommand@2
-  displayName: NuGet restore System.Net.Sockets.TcpClient
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    restoreSolution: 'System.Net.Sockets.TcpClient\nanoFramework.System.Net.Sockets.TcpClient.sln'
-    feedsToUse: config
-    nugetConfigPath: 'System.Net.Sockets.TcpClient\NuGet.Config'
-
-- task: NuGetCommand@2
-  displayName: NuGet restore System.Net.Sockets.UdpClient
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    restoreSolution: 'System.Net.Sockets.UdpClient\nanoFramework.System.Net.Sockets.UdpClient.sln'
-    feedsToUse: config
-    nugetConfigPath: 'System.Net.Sockets.UdpClient\NuGet.Config'
-
-# we only need to reference the main nuget.config 
-- task: NuGetCommand@2
-  displayName: NuGet restore nanoFramework.IoT.Device
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    restoreSolution: 'nanoFramework.IoT.Device\devices\**\*.sln'
-    feedsToUse: config
-    nugetConfigPath: 'nanoFramework.IoT.Device\NuGet.Config'
+    restoreSolution: 'libs/**/*.sln'
+    feedsToUse: 'select'
 
 # Build part
 - task: InstallNanoMSBuildComponents@1
+  displayName: Install nanoFramework MSBuild components
   condition: >-
     and(
       succeeded(),
@@ -1209,13 +407,15 @@ steps:
         eq(variables['BuildOptions.BUILD_ALL'], 'true')
       )
     )
-  displayName: Install nanoFramework MSBuild components
+  inputs:
+    GitHubToken: $(GitHubToken)
 
-- task: VSBuild@1
-  displayName: Build CoreLibrary
+# this is required for IoT bindings build
+- task: DotNetCoreCLI@2  
+  displayName: Install nanovc tool
   condition: >-
     and(
-      succeeded(), 
+      succeeded(),
       or(
         eq(variables['BUILD_ALL'], 'true'),
         contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
@@ -1223,850 +423,36 @@ steps:
       )
     )
   inputs:
-    solution: 'CoreLibrary\nanoFramework.CoreLibrary.sln'
-    platform: '$(buildPlatform)'
-    configuration: '$(buildConfiguration)'
-    maximumCpuCount: true
-
-- task: VSBuild@1
-  displayName: Build nanoFramework.Device.Can
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    solution: 'nanoFramework.Device.Can\nanoFramework.Device.Can.sln'
-    platform: '$(buildPlatform)'
-    configuration: '$(buildConfiguration)'
-    maximumCpuCount: true
-
-- task: VSBuild@1
-  displayName: Build nanoFramework.Device.OneWire
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    solution: 'nanoFramework.Device.OneWire\nanoFramework.Device.OneWire.sln'
-    platform: '$(buildPlatform)'
-    configuration: '$(buildConfiguration)'
-    maximumCpuCount: true
-
-- task: VSBuild@1
-  displayName: Build nanoFramework.Runtime.Events
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    solution: 'nanoFramework.Runtime.Events\nanoFramework.Runtime.Events.sln '
-    platform: '$(buildPlatform)'
-    configuration: '$(buildConfiguration)'
-    maximumCpuCount: true
-
-- task: VSBuild@1
-  displayName: Build nanoFramework.Runtime.Native
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    solution: 'nanoFramework.Runtime.Native\nanoFramework.Runtime.Native.sln'
-    platform: '$(buildPlatform)'
-    configuration: '$(buildConfiguration)'
-    maximumCpuCount: true
-
-- task: VSBuild@1
-  displayName: Build nanoFramework.WebServer
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    solution: 'nanoFramework.WebServer\nanoFramework.WebServer.sln'
-    platform: '$(buildPlatform)'
-    configuration: '$(buildConfiguration)'
-    maximumCpuCount: true
+    command: custom
+    custom: tool
+    arguments: install -g nanovc --add-source https://pkgs.dev.azure.com/nanoframework/feed/_packaging/sandbox/nuget/v3/index.json
   
+# This will build all class libraries in the libs folder
 - task: VSBuild@1
-  displayName: Build nanoFramework.DependencyInjection
+  displayName: Build all class libs
   condition: >-
     and(
-      succeeded(), 
+      succeeded(),
       or(
         eq(variables['BUILD_ALL'], 'true'),
         contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
         eq(variables['BuildOptions.BUILD_ALL'], 'true')
       )
     )
+  retryCountOnTaskFailure: 3
   inputs:
-    solution: 'nanoFramework.DependencyInjection\nanoFramework.DependencyInjection.sln'
+    solution: 'libs/**/*.sln'
     platform: '$(buildPlatform)'
     configuration: '$(buildConfiguration)'
-    maximumCpuCount: true
-
-- task: VSBuild@1
-  displayName: Build nanoFramework.Hosting
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    solution: 'nanoFramework.Hosting\nanoFramework.Hosting.sln'
-    platform: '$(buildPlatform)'
-    configuration: '$(buildConfiguration)'
-    maximumCpuCount: true
-
-- task: VSBuild@1
-  displayName: Build System.Device.Dac
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    solution: 'System.Device.Dac\nanoFramework.System.Device.Dac.sln'
-    platform: '$(buildPlatform)'
-    configuration: '$(buildConfiguration)'
-    maximumCpuCount: true
-
-- task: VSBuild@1
-  displayName: Build System.Device.Gpio
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    solution: 'System.Device.Gpio\nanoFramework.System.Device.Gpio.sln'
-    platform: '$(buildPlatform)'
-    configuration: '$(buildConfiguration)'
-    maximumCpuCount: true
-
-- task: VSBuild@1
-  displayName: Build Windows.Devices.Gpio
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    solution: 'Windows.Devices.Gpio\nanoFramework.Windows.Devices.Gpio.sln'
-    platform: '$(buildPlatform)'
-    configuration: '$(buildConfiguration)'
-    maximumCpuCount: true
-
-- task: VSBuild@1
-  displayName: Build Windows.Devices.I2c
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    solution: 'Windows.Devices.I2c\nanoFramework.Windows.Devices.I2c.sln'
-    platform: '$(buildPlatform)'
-    configuration: '$(buildConfiguration)'
-    maximumCpuCount: true
-
-- task: VSBuild@1
-  displayName: Build System.Device.I2c
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    solution: 'System.Device.I2c\nanoFramework.System.Device.I2c.sln'
-    platform: '$(buildPlatform)'
-    configuration: '$(buildConfiguration)'
-    maximumCpuCount: true
-
-- task: VSBuild@1
-  displayName: Build System.Device.I2s
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    solution: 'System.Device.I2s\nanoFramework.System.Device.I2s.sln'
-    platform: '$(buildPlatform)'
-    configuration: '$(buildConfiguration)'
-    maximumCpuCount: true
-
-- task: VSBuild@1
-  displayName: Build System.IO.FileSystem
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    solution: 'System.IO.FileSystem\nanoFramework.System.IO.FileSystem.sln'
-    platform: '$(buildPlatform)'
-    configuration: '$(buildConfiguration)'
-    maximumCpuCount: true
-
-- task: VSBuild@1
-  displayName: Build System.IO.Streams
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    solution: 'System.IO.Streams\nanoFramework.System.IO.Streams.sln'
-    platform: '$(buildPlatform)'
-    configuration: '$(buildConfiguration)'
-    maximumCpuCount: true
-
-- task: VSBuild@1
-  displayName: Build System.Runtime.Serialization
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    solution: 'System.Runtime.Serialization\nanoFramework.System.Runtime.Serialization.sln'
-    platform: '$(buildPlatform)'
-    configuration: '$(buildConfiguration)'
-    maximumCpuCount: true
-
-- task: VSBuild@1
-  displayName: Build Windows.Devices.Pwm
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    solution: 'Windows.Devices.Pwm\nanoFramework.Windows.Devices.Pwm.sln'
-    platform: '$(buildPlatform)'
-    configuration: '$(buildConfiguration)'
-    maximumCpuCount: true
-
-- task: VSBuild@1
-  displayName: Build System.Device.Pwm
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    solution: 'System.Device.Pwm\nanoFramework.System.Device.Pwm.sln'
-    platform: '$(buildPlatform)'
-    configuration: '$(buildConfiguration)'
-    maximumCpuCount: true
-
-- task: VSBuild@1
-  displayName: Build Windows.Devices.SerialCommunication
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    solution: 'Windows.Devices.SerialCommunication\nanoFramework.Windows.Devices.SerialCommunication.sln'
-    platform: '$(buildPlatform)'
-    configuration: '$(buildConfiguration)'
-    maximumCpuCount: true
-
-- task: VSBuild@1
-  displayName: Build Windows.Devices.Spi
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    solution: 'Windows.Devices.Spi\nanoFramework.Windows.Devices.Spi.sln'
-    platform: '$(buildPlatform)'
-    configuration: '$(buildConfiguration)'
-    maximumCpuCount: true
-
-- task: VSBuild@1
-  displayName: Build System.Device.Spi
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    solution: 'System.Device.Spi\nanoFramework.System.Device.Spi.sln'
-    platform: '$(buildPlatform)'
-    configuration: '$(buildConfiguration)'
-    maximumCpuCount: true
-
-- task: VSBuild@1
-  displayName: Build Windows.Storage
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    solution: 'Windows.Storage\nanoFramework.Windows.Storage.sln'
-    platform: '$(buildPlatform)'
-    configuration: '$(buildConfiguration)'
-    maximumCpuCount: true
-
-- task: VSBuild@1
-  displayName: Build Windows.Storage.Streams
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    solution: 'Windows.Storage.Streams\nanoFramework.Windows.Storage.Streams.sln'
-    platform: '$(buildPlatform)'
-    configuration: '$(buildConfiguration)'
-    maximumCpuCount: true
-
-- task: VSBuild@1
-  displayName: Build Windows.Devices.Adc
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    solution: 'Windows.Devices.Adc\nanoFramework.Windows.Devices.Adc.sln'
-    platform: '$(buildPlatform)'
-    configuration: '$(buildConfiguration)'
-    maximumCpuCount: true
-    
-- task: VSBuild@1
-  displayName: Build System.Device.Adc
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    solution: 'System.Device.Adc\nanoFramework.System.Device.Adc.sln'
-    platform: '$(buildPlatform)'
-    configuration: '$(buildConfiguration)'
-    maximumCpuCount: true
-
-- task: VSBuild@1
-  displayName: Build System.Device.WiFi
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    solution: 'System.Device.WiFi\nanoFramework.System.Device.WiFi.sln'
-    platform: '$(buildPlatform)'
-    configuration: '$(buildConfiguration)'
-    maximumCpuCount: true
-
-- task: VSBuild@1
-  displayName: Build nanoFramework.Benchmark
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    solution: 'nanoFramework.Benchmark\nanoFramework.Benchmark.sln'
-    platform: '$(buildPlatform)'
-    configuration: '$(buildConfiguration)'
-    maximumCpuCount: true
-
-- task: VSBuild@1
-  displayName: Build nanoFramework.Graphics
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    solution: 'nanoFramework.Graphics\nanoFramework.Graphics.sln'
-    platform: '$(buildPlatform)'
-    configuration: '$(buildConfiguration)'
-    maximumCpuCount: true
-
-- task: VSBuild@1
-  displayName: Build nanoFramework.Hardware.Esp32
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    solution: 'nanoFramework.Hardware.Esp32\nanoFramework.Hardware.Esp32.sln'
-    platform: '$(buildPlatform)'
-    configuration: '$(buildConfiguration)'
-    maximumCpuCount: true
-
-- task: VSBuild@1
-  displayName: Build nanoFramework.Hardware.Esp32.Rmt
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    solution: 'nanoFramework.Hardware.Esp32.Rmt\nanoFramework.Hardware.Esp32.Rmt.sln'
-    platform: '$(buildPlatform)'
-    configuration: '$(buildConfiguration)'
-    maximumCpuCount: true
-
-- task: VSBuild@1
-  displayName: Build nanoFramework.Json
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    solution: 'nanoFramework.Json\nanoFramework.Json.sln'
-    platform: '$(buildPlatform)'
-    configuration: '$(buildConfiguration)'
-    maximumCpuCount: true
-
-- task: VSBuild@1
-  displayName: Build nanoFramework.Hardware.Stm32
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    solution: 'nanoFramework.Hardware.Stm32\nanoFramework.Hardware.Stm32.sln'
-    platform: '$(buildPlatform)'
-    configuration: '$(buildConfiguration)'
-    maximumCpuCount: true
-
-- task: VSBuild@1
-  displayName: Build nanoFramework.Networking.Sntp
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    solution: 'nanoFramework.Networking.Sntp\nanoFramework.Networking.Sntp.sln'
-    platform: '$(buildPlatform)'
-    configuration: '$(buildConfiguration)'
-    maximumCpuCount: true
-
-- task: VSBuild@1
-  displayName: Build System.Collections
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    solution: 'System.Collections\nanoFramework.System.Collections.sln'
-    platform: '$(buildPlatform)'
-    configuration: '$(buildConfiguration)'
-    maximumCpuCount: true
-
-- task: VSBuild@1
-  displayName: Build System.Text
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    solution: 'System.Text\nanoFramework.System.Text.sln'
-    platform: '$(buildPlatform)'
-    configuration: '$(buildConfiguration)'
-    maximumCpuCount: true
-
-- task: VSBuild@1
-  displayName: Build System.Net
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    solution: 'System.Net\nanoFramework.System.Net.sln'
-    platform: '$(buildPlatform)'
-    configuration: '$(buildConfiguration)'
-    maximumCpuCount: true
-
-- task: VSBuild@1
-  displayName: Build System.Net.Http
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    solution: 'System.Net.Http\nanoFramework.System.Net.Http.sln'
-    platform: '$(buildPlatform)'
-    configuration: '$(buildConfiguration)'
-    maximumCpuCount: true
-
-- task: VSBuild@1
-  displayName: Build System.Net.WebSockets
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    solution: 'System.Net.WebSockets\nanoFramework.System.Net.WebSockets.sln'
-    platform: '$(buildPlatform)'
-    configuration: '$(buildConfiguration)'
-    maximumCpuCount: true
-
-- task: VSBuild@1
-  displayName: Build nanoFramework.Hardware.TI
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    solution: 'nanoFramework.Hardware.TI\nanoFramework.Hardware.TI.sln'
-    platform: '$(buildPlatform)'
-    configuration: '$(buildConfiguration)'
-    maximumCpuCount: true
-
-- task: VSBuild@1
-  displayName: Build System.Math
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    solution: 'System.Math\nanoFramework.System.Math.sln'
-    platform: '$(buildPlatform)'
-    configuration: '$(buildConfiguration)'
-    maximumCpuCount: true
-
-- task: VSBuild@1
-  displayName: Build nanoFramework.Logging
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    solution: 'nanoFramework.Logging\nanoFramework.Logging.sln'
-    platform: '$(buildPlatform)'
-    configuration: '$(buildConfiguration)'
-    maximumCpuCount: true
-
-- task: VSBuild@1
-  displayName: Build System.IO.Ports
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    solution: 'System.IO.Ports\nanoFramework.System.IO.Ports.sln'
-    platform: '$(buildPlatform)'
-    configuration: '$(buildConfiguration)'
-    maximumCpuCount: true
-
-- task: VSBuild@1
-  displayName: Build nanoFramework.M2Mqtt
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    solution: 'nanoFramework.M2Mqtt\nanoFramework.M2Mqtt.sln'
-    platform: '$(buildPlatform)'
-    configuration: '$(buildConfiguration)'
-    maximumCpuCount: true
-
-- task: VSBuild@1
-  displayName: Build System.Text.RegularExpressions
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    solution: 'System.Text.RegularExpressions\nanoFramework.System.Text.RegularExpressions.sln'
-    platform: '$(buildPlatform)'
-    configuration: '$(buildConfiguration)'
-    maximumCpuCount: true
-
-- task: VSBuild@1
-  displayName: Build nanoFramework.Azure.Devices
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    solution: 'nanoFramework.Azure.Devices\nanoFramework.Azure.Devices.Client.sln'
-    platform: '$(buildPlatform)'
-    configuration: '$(buildConfiguration)'
-    maximumCpuCount: true
-
-- task: VSBuild@1
-  displayName: Build nanoFramework.Aws.IoTCore.Devices
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    solution: 'nanoFramework.Aws.IoTCore.Devices\nanoFramework.Aws.IoTCore.Devices.sln'
-    platform: '$(buildPlatform)'
-    configuration: '$(buildConfiguration)'
-    maximumCpuCount: true
-
-- task: VSBuild@1
-  displayName: Build nanoFramework.SignalR.Client
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    solution: 'nanoFramework.SignalR.Client\nanoFramework.SignalR.Client.sln'
-    platform: '$(buildPlatform)'
-    configuration: '$(buildConfiguration)'
-    maximumCpuCount: true
-
-- task: VSBuild@1
-  displayName: Build System.Net.Sockets.TcpClient
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    solution: 'System.Net.Sockets.TcpClient\nanoFramework.System.Net.Sockets.TcpClient.sln'
-    platform: '$(buildPlatform)'
-    configuration: '$(buildConfiguration)'
-    maximumCpuCount: true
-
-- task: VSBuild@1
-  displayName: Build System.Net.Sockets.UdpClient
-  condition: >-
-    and(
-      succeeded(), 
-      or(
-        eq(variables['BUILD_ALL'], 'true'),
-        contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
-        eq(variables['BuildOptions.BUILD_ALL'], 'true')
-      )
-    )
-  inputs:
-    solution: 'System.Net.Sockets.UdpClient\nanoFramework.System.Net.Sockets.UdpClient.sln'
-    platform: '$(buildPlatform)'
-    configuration: '$(buildConfiguration)'
+    msbuildArchitecture: 'x64'
     maximumCpuCount: true
 
 # This should build all the bindings in nanoFramework.IoT.Device in the devices directory
-- task: VSBuild@1
-  displayName: Build nanoFramework.IoT.Device
+- task: PowerShell@2
+  displayName: Build all from nanoFramework.IoT.Device
   condition: >-
     and(
-      succeeded(), 
+      succeeded(),
       or(
         eq(variables['BUILD_ALL'], 'true'),
         contains(variables['BuildOptions.COMMIT_MESSAGE'], '***BUILD_ALL***'),
@@ -2074,11 +460,12 @@ steps:
       )
     )
   inputs:
-    solution: 'nanoFramework.IoT.Device\devices\**\*.sln'
-    platform: '$(buildPlatform)'
-    configuration: '$(buildConfiguration)'
-    maximumCpuCount: true
-  continueOnError: true
+    workingDirectory: 'nanoFramework.IoT.Device\devices'
+    targetType: 'filePath'
+    filePath: 'nanoFramework.IoT.Device\.pipeline-assets\pipeline-build-solutions.PS1'
+  env:
+    MY_GITHUBTOKEN: $(GitHubToken)
+    DEVICE_TO_BUILD: 'ALL'
 
 # Clean what's not needed from IoT.Device and adjust the nugets to remove nerdbank to help build
 - task: PowerShell@2
@@ -2185,16 +572,16 @@ steps:
 
 # commit changes
 - powershell: |
-        git clone https://github.com/nanoframework/nanoframework.github.io.git -b master origin_site -q
-        Copy-Item _site/* origin_site -recurse -Force
-        
-        cd origin_site > $null
+    git clone https://github.com/nanoframework/nanoframework.github.io.git -b master origin_site -q
+    Copy-Item _site/* origin_site -recurse -Force
+    
+    cd origin_site > $null
 
-        $auth = "basic $([System.Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes("nfbot:$(GitHubToken)"))))"
+    $auth = "basic $([System.Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes("nfbot:$(GitHubToken)"))))"
 
-        git add . -A > $null
-        git commit -m "Update documentation from PR" -q > $null
-        git -c http.extraheader="AUTHORIZATION: $auth" push origin master -q > $null
+    git add . -A > $null
+    git commit -m "Update documentation from PR" -q > $null
+    git -c http.extraheader="AUTHORIZATION: $auth" push origin master -q > $null
   failOnStderr: false
   ignoreLASTEXITCODE: true
   condition: >-

--- a/docfx.json
+++ b/docfx.json
@@ -4,7 +4,7 @@
       "src": [
         {
           "files": [
-            "**/*.csproj"
+            "libs/**/*.csproj"
           ],
           "exclude": [
             "**/obj/**",
@@ -33,7 +33,8 @@
             "**/Tests/**",
             "**/Test/**",
             "**/**.Test*",
-            "**/samples/**"
+            "**/samples/**",
+            "libs/**"
           ]
         }
       ],
@@ -110,7 +111,7 @@
     "cleanupCacheHistory": false,
     "disableGitFeatures": false,
     "globalMetadata": {
-      "_appTitle": "nanoFramework Documentation",
+      "_appTitle": ".NET nanoFramework Documentation",
       "_enableSearch": true,
       "_gitContribute": {
         "branch": "pages-source"


### PR DESCRIPTION
## Description
- Migrate build image to windows latest.
- Request to GitHub API are now authenticated.
- Split clone step in two: libs and IoT bindings.
- Clone of class libs is now made to `libs` folder.
- Nuget restore is now a single step with a wildcard on filter to catch all class libs.
- VSBuild is now a single step for all class libs.
- Building of IoT bindings is now using the PS1 script of the repo to take care of this.
- Update docfx filters to catch docs for class libs in new location.
- Add new docs to exclusion list for build trigger.
- Minor style improvements in AZDO yaml file.

## Motivation and Context
- Migrate to latest AZDO build image.
- General simplification of pipeline.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (correction, content improvement, typo fix, formatting)
- [ ] New Article (new document for docs website)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My doc follows the code style of this project.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
