### PR TITLE
updated expected format of NF_INTEROP_ASSSEMBLIES

### DIFF
--- a/content/building/cmake-presets.md
+++ b/content/building/cmake-presets.md
@@ -179,8 +179,8 @@ Below is a list of the build options available (last updated October 2022). Thes
 - "NF_CLR_NO_IL_INLINE" : **`OFF`**
   - Allows you to define if CLR will use IL inlining.
   Default is `OFF` meaning that CLR will inline IL.
-- "NF_INTEROP_ASSEMBLIES" : [ "Assembly1-Namespace", "Assembly2-Namespace" ]
-  - Lists the name of the Interop assembly(ies) to be added to the build. Leave empty or don't add it if no Interop assembly is to be added.
+- "NF_INTEROP_ASSEMBLIES" : "Assembly1-Namespace Assembly2-Namespace Assembly3-Namespace"
+  - Lists the name of the Interop assembly(ies) to be added to the build in a space separated string. Leave empty or don't add it if no Interop assembly is to be added.
 - "NF_NETWORKING_SNTP" : **`ON`**
   - Allows you to specify whether SNTP is enabled. Requires networking feature to be enabled. Default is ON.
 - "NF_SECURITY_MBEDTLS" : **`OFF`**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
updated documentation for CMake presets to reflect the correct format for NF_INTEROP_ASSEMBLIES variable

## Motivation and Context
- expected format changed from string array to space separated string list

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (correction, content improvement, typo fix, formatting)
- [ ] New Article (new document for docs website)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My doc follows the code style of this project.
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
