### PR TITLE
ADC explanation typo for 8 bit resolution - should say 256 values instead of 1024

### DIFF
--- a/content/getting-started-guides/adc-explained.md
+++ b/content/getting-started-guides/adc-explained.md
@@ -38,7 +38,7 @@ Note that the variable resistor can be either on the [Pull-up or Pull-down](./gp
 
 The electronics doing this [ADC conversion is quite complex](https://en.wikipedia.org/wiki/Analog-to-digital_converter). We will not explained how it is working under the hook as it is not useful for using it.
 
-The analogic voltage is then converted into bytes with a resolution in bits. The more precise is the ADC, the higher the resolution is. So, if you have a 8 bits resolution, you will get 1024 possible values going from 0 to 1023. If you have a 12 bits resolution, you will get 4096 values going from 0 to 4095.
+The analogic voltage is then converted into bytes with a resolution in bits. The more precise is the ADC, the higher the resolution is. So, if you have a 8 bits resolution, you will get 256 possible values going from 0 to 255. If you have a 12 bits resolution, you will get 4096 values going from 0 to 4095.
 
 ## ADC in practice
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Fixed possible values for the 8 bits resolution. It should says "256 possible values going from 0 to 255" instead of "you will get 1024 possible values going from 0 to 1023"

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes/resolves an open issue, please link to the issue here using the template bellow (mind the link as all issues are open in the Home repository, not in this one) -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (correction, content improvement, typo fix, formatting)
- [ ] New Article (new document for docs website)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My doc follows the code style of this project.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
