### PR TITLE
Remove PoC projects of Test framework so they don't generate documentation

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -15,6 +15,7 @@
             "**/**.Test*",
             "nanoFramework.IoT.Device/**",
             "**/TestAdapter/**",
+            "**/poc/TestOfTestFramework/**",
             "**/poc/TestOfTestFrameworkByReference/**"
           ]
         }
@@ -114,7 +115,7 @@
       "templates/nano",
       "modern",
       "templates/material"
-    ],    
+    ],
     "postProcessors": [ "ExtractSearchIndex" ],
     "xrefService": [ "https://xref.docs.microsoft.com/query?uid={uid}" ],
     "noLangKeyword": false,
@@ -131,5 +132,3 @@
     }
   }
 }
-
-


### PR DESCRIPTION
## Description
This PR: exclude TestOfTestFramework as source for docfx - this is the other test project for the test framework

## Motivation and Context
The nanoFramework.TestFramework documentation is missing from the API reference, but one of the [test projects](https://docs.nanoframework.net/api/nanoFramework.TestFramework.Test.html) is documented. This PR addresses the second issue by excluding it in the same way the other test project is excluded.

## Types of changes
- [ ] Improvement (correction, content improvement, typo fix, formatting)
- [ ] New Article (new document for docs website)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My doc follows the code style of this project.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
