### PR TITLE
Update build instructions with Kconfig options

### DIFF
--- a/content/building/build-esp32.md
+++ b/content/building/build-esp32.md
@@ -26,8 +26,9 @@ You'll need:
   . [C/C++](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools) - C/C++ IntelliSense, debugging, and code browsing (by Microsoft)
   . [CMake Tools](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cmake-tools) - Extended CMake support in Visual Studio Code (by Microsoft)
 - [CMake](https://cmake.org/download/) (Minimum required version is 3.21)
-- [Python 3.8](https://www.python.org/downloads/release/python-368) Required for uploading the nanoCLR to the ESP32.
+- [Python 3.8](https://www.python.org/downloads/release/python-368) Required for uploading the nanoCLR to the ESP32 and for the Kconfig target configuration system.
   - Ensure the Windows default app to open `.py` files is Python.
+  - Install kconfiglib: `pip install kconfiglib`
 - A build system for CMake to generate the build files to. We recommend [Ninja](https://github.com/ninja-build/ninja/releases).
 - [ESP-IDF Tools](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/get-started/windows-setup.html).
 - Driver for the USB to UART Bridge. This depends on the ESP32 hardware. After installing it, use Windows Device Manager to determine the COM port as this is needed to complete the setup. Follows the most common drivers (all these are available along with ESP-IDF tools installer):

--- a/content/building/build-nxp.md
+++ b/content/building/build-nxp.md
@@ -28,6 +28,8 @@ You'll need:
   . [Cortex Debug](https://github.com/Marus/cortex-debug)) - Debug tool made explicity for ARM Cortex-M cores (needed for J-Link), if you're using on board programmer you don't need it.
 - [CMake](https://cmake.org/download/) (Minimum required version is 3.21)
 - A build system for CMake to generate the build files to. We recommend [Ninja](https://github.com/ninja-build/ninja/releases).
+- [Python 3.8](https://www.python.org/downloads/) or later. Required for the Kconfig target configuration system and various build scripts.
+  - Install kconfiglib: `pip install kconfiglib`
 - [GNU ARM Embedded Toolchain](https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads)
 - OpenOCD. Suggest the [xPack OpenOCD](https://github.com/xpack-dev-tools/openocd-xpack/releases) that kindly maintains a Windows distribution.
 

--- a/content/building/build-stm32.md
+++ b/content/building/build-stm32.md
@@ -27,6 +27,8 @@ You'll need:
   . [CMake Tools](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cmake-tools) - Extended CMake support in Visual Studio Code (by Microsoft)
 - [CMake](https://cmake.org/download/) (Minimum required version is 3.21)
 - A build system for CMake to generate the build files to. We recommend [Ninja](https://github.com/ninja-build/ninja/releases).
+- [Python 3.8](https://www.python.org/downloads/) or later. Required for the Kconfig target configuration system and various build scripts.
+  - Install kconfiglib: `pip install kconfiglib`
 - [GNU ARM Embedded Toolchain](https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads)
 - OpenOCD. We suggest [Microsoft build](https://github.com/microsoft/openocd) which provides a Windows distribution including convenient fixes for working with Azure RTOS.
 - [ChibiOS](https://www.chibios.org/dokuwiki/doku.php) - Technically you do not need to download this, the build scripts will do this automatically if you do not specify a path to ChibiOS in the `CHIBIOS_SOURCE_FOLDER` build option (more info in the [Set up Visual Studio Code section](#set-up-visual-studio-code)).

--- a/content/building/cmake-presets.md
+++ b/content/building/cmake-presets.md
@@ -4,53 +4,23 @@
 
 This document describes how to use and modify the CMake presets to suit your needs.
 
-**CMakePresets.json** and **CMakeUserPresets.TEMPLATE.json** files to suit your needs.
+> **Important:** Target and hardware/feature configuration has been migrated to [Kconfig](kconfig-options.md). CMake presets now only contain build-system settings (toolchain, generator, output paths, tool paths). For configuring target features, APIs, and hardware options see the [Kconfig options](kconfig-options.md) documentation.
 
 ## Introduction
 
-Our build system uses [CMake](https://cmake.org/) and [CMake presets](https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html) to configure the various build options.
+Our build system uses [CMake](https://cmake.org/) and [CMake presets](https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html) to configure the build-system level options.
 The build can be managed and configured using a command prompt or directly from [VS Code](https://github.com/microsoft/vscode-cmake-tools/blob/main/docs/cmake-presets.md) or [Visual Studio](https://learn.microsoft.com/en-us/cpp/build/cmake-presets-vs?view=msvc-160).
 
-The simplest way to tweak a build or configuration preset is to create a `CMakeUserPresets.json` and override in this file, any of the configurations and options set in the presets. You can read more details on how the user presets work on the document above about CMake presets.
+CMake presets are now limited to build-system configuration. All hardware, feature and API configuration has moved to [Kconfig](kconfig-options.md) with per-target `defconfig` files.
 
-Follows an example to illustrate how this works. Let's imagine that a developer working on a ESP32 WROVER KIT doesn't need support for the display and is not interest in support for SD Card either.
-Both options are being set in the target preset, so it's a simple matter of overriding them like this:
+Developer-local adjustments are split across two systems:
 
-```json
-{
-    "version": 4,
-    "configurePresets": [
-        {
-            "name": "MY_ESP_WROVER_KIT",
-            "hidden": true,
-            "inherits": [
-                "ESP_WROVER_KIT"
-            ],           
-            "cacheVariables": {
-                "NF_FEATURE_HAS_SDCARD": "OFF",
-                "API_nanoFramework.Graphics": "OFF"
-            }
-        },      
-    ],
-    "buildPresets": [
-        {
-            "name": "MY_ESP_WROVER_KIT",
-            "displayName": "MY_ESP_WROVER_KIT",
-            "configurePreset": "MY_ESP_WROVER_KIT"
-        }
-    ] 
-}
-```
-
-With the above, a new configure preset named `MY_ESP_WROVER_KIT` was created inheriting the original preset `ESP_WROVER_KIT` and overriding the build options that one is interested in changing. Following this a new build preset is also created to expose the configure preset.
-With the above a new configure preset `MY_ESP_WROVER_KIT` is made available and ready to be used in CMake CLI, VS Code or Visual Studio.
-
-Other adjustments, with potentially broader impact, can be made in the `config\user-prefs.json` and `config\user-tools-repos.json` preset files.
+- **CMake-level**: `config/user-prefs.json` — for build type, tool paths, SDK paths, build version and similar build-system variables.
+- **Kconfig-level**: `config/user-kconfig.conf` — for target features, APIs, RTM mode, CLR trace flags and similar target configuration. See [Kconfig options](kconfig-options.md) for details.
 
 ## Build options for CMake Presets
 
-Below is a list of the build options available (last updated October 2022). These can be found at the various CMake presets files available.
-***Note:*** some of these options are specific to the `RTOS` or target type.
+Below is a list of the build options that **remain** in CMake presets. These are build-system variables that are not part of target configuration.
 
 - "BUILD_VERSION" : "**version-number-for-the-build-format-is-N.N.N.N**"
   - This can be used [to prevent a board from updating if working on a custom firmware](../faq/automatic-firmware-updates.md)
@@ -59,195 +29,98 @@ Below is a list of the build options available (last updated October 2022). Thes
   - Option to output verbose messages during build. Useful for debugging issues with build system.
 - "TOOL_HEX2DFU_PREFIX" : "**absolute-path-to-hex2dfu-utility-mind-the-forward-slash**"
   - This is the path to the HEX2DFU utility. Use forward slashes and do not provide executable name here.
-- "TARGET_BOARD"
-  - Valid target name from platform boards collection.
+- "TOOL_SRECORD_PREFIX" : "**absolute-path-to-srecord-utility-mind-the-forward-slash**"
+  - This is the path to the SRecord utility. Use forward slashes and do not provide executable name here.
 - "ESP32_IDF_PATH" : "**absolute-path-to-esp-idf-mind-the-forward-slash**"
   - This the path to the ESP32 IDF utility. Use forward slashes and do not provide executable name here.
 - "EXECUTABLE_OUTPUT_PATH" : "**${workspaceRoot}/build**"
   - This is the default and recommended path which will expand to the build folder when building from VS Code. When building from the command line or from Visual Studio this is not required.
-- "TARGET_SERIES" : "**STM32F7xx**"
-  - For STM32 MCUs represents the target series (STM32F4XX, STM32L4XX, and so on)
-  - For ESP32 represents the target series (ESP32, ESP32_S2, and so on)
-  - For NXP represents the target series (IMXRT10xx)
-  - For TI SimpleLink targets represents the target series (CC13X2, CC32xx)
-- "TARGET_SERIAL_BAUDRATE"
-  - Baudrate for serial communication. Only required to override default.
-- "TARGET_NAME"
-  - Required only if need to override the target name on the firmware.
-- "USE_RNG" : **`ON`**
-  - Option to enable the use of the hardware true random generator unit, if present. Default is ON as the majority of the targets have this feature.
-- "DP_FLOATINGPOINT" : **`OFF`**
-  - Enables support for double-precision floating point. The default is single-precision. Set to ON to enable double precision floating point.
-- "SUPPORT_ANY_BASE_CONVERSION" : **`OFF`**
-  - Defines which bases are supported when performing string to value conversions. When ON support for any base is enabled. When `OFF` (the default) the image will be compiled with support for base 10 and base 16 only.
-- "RTOS" : "**one-of-valid-rtos-options**"
-  - Defines the RTOS that will be used to build nanoFramework. Valid options: ChibiOS, ESP32, AzureRTOS and FreeRTOS.
 - "CHIBIOS_SOURCE_FOLDER" : ""
   - Path to an optional local installation of ChibiOS source files. If no path is given, then CMake will download the sources automatically from ChibiOS SVN repository when required. Mind the forward slash.
-- "CHIBIOS_HAL_REQUIRED" : **`OFF`**
-  - Set to ON to include ChibiOS HAL repository in the build.
 - "CHIBIOS_HAL_SOURCE": ""
-  - Path to an optional local installation of ChibiOS source files. If no path is given, then CMake will download the sources automatically from ChibiOS SVN repository when required. Mind the forward slash.
-- "CHIBIOS_HAL_VERSION": ""
-  - Valid ChibiOS version. If empty use default CMake setting.
-- "CHIBIOS_CONTRIB_REQUIRED": **`OFF`**
-  - Set to ON to include ChibiOS Contrib repository in the build.
+  - Path to an optional local installation of ChibiOS HAL source files. If no path is given, then CMake will download the sources automatically from ChibiOS SVN repository when required. Mind the forward slash.
 - "CHIBIOS_CONTRIB_SOURCE": ""
   - Path to an optional local installation of ChibiOS Contrib source files. If no path is given, then CMake will download the sources automatically from ChibiOS Contrib repository when required. Mind the forward slash.
 - "FREERTOS_SOURCE_FOLDER": ""
   - Path to an optional local installation of FreeRTOS source files. If no path is given, then CMake will download the sources automatically from FreeRTOS repository when required. Mind the forward slash.
 - "CMSIS_SOURCE": ""
   - Path to an optional local installation of CMSIS source files. If no path is given, then CMake will download the sources automatically from CMSIS repository when required. Mind the forward slash.
-- "CMSIS_VERSION": ""
-  - Valid CMSIS version. If empty use default CMake setting.
-- "STM32_CUBE_PACKAGE_REQUIRED": **`OFF`**
-  - Set to ON to include STM Cube package in the build.
 - "STM32_HAL_DRIVER_SOURCE": ""
-  - Path to an optional local installation of CMSIS source files. If no path is given, then CMake will download the sources automatically from CMSIS repository when required. Mind the forward slash.
+  - Path to an optional local installation of STM32 HAL driver source files. If no path is given, then CMake will download the sources automatically. Mind the forward slash.
 - "STM32_CMSIS_DEVICE_SOURCE": ""
-  - Path to an optional local installation of CMSIS device source files. If no path is given, then CMake will download the sources automatically from CMSIS device repository when required. Mind the forward slash.
+  - Path to an optional local installation of CMSIS device source files. If no path is given, then CMake will download the sources automatically. Mind the forward slash.
 - "STM32_CMSIS_CORE_SOURCE": ""
-  - Path to an optional local installation of SMT32 CMSIS source files. If no path is given, then CMake will download the sources automatically from SMT32 CMSIS repository when required. Mind the forward slash.
+  - Path to an optional local installation of STM32 CMSIS source files. If no path is given, then CMake will download the sources automatically. Mind the forward slash.
 - "TI_SL_CC32xx_SDK_SOURCE": ""
-  - Path to an optional local installation of SMT32 CMSIS source files. If no path is given, then CMake will download the sources automatically from SMT32 CMSIS repository when required. Mind the forward slash.
-<path-to-local-TI_SimpleLink-CC32xx-SDK-source-mind-the-forward-slash>",
+  - Path to an optional local installation of TI SimpleLink CC32xx SDK source files. If no path is given, then CMake will download the sources automatically. Mind the forward slash.
 - "TI_SL_CC13xx_26xx_SDK_SOURCE": ""
-  - Path to an optional local installation of TI SimpleLink CC13xx_26xx SDK source files. If no path is given, then CMake will download the sources automatically from TI SimpleLink CC13xx_26xx SDK repository when required. Mind the forward slash.
+  - Path to an optional local installation of TI SimpleLink CC13xx_26xx SDK source files. If no path is given, then CMake will download the sources automatically. Mind the forward slash.
 - "TI_XDCTOOLS_SOURCE": ""
-  - Path to an optional local installation of TI XDC Tools source files. If no path is given, then CMake will download the sources automatically from TI XDC Tools repository when required. Mind the forward slash.
+  - Path to an optional local installation of TI XDC Tools source files. If no path is given, then CMake will download the sources automatically. Mind the forward slash.
 - "TI_SYSCONFIG_SOURCE": ""
-  - Path to an optional local installation of TI SysConfig source files. If no path is given, then CMake will download the sources automatically from TI SysConfig repository when required. Mind the forward slash.
-- "RADIO_FREQUENCY": "915",
-  - Valid frequency for CC13xx_26xx targets. Possible values are 868 and 915.
+  - Path to an optional local installation of TI SysConfig source files. If no path is given, then CMake will download the sources automatically. Mind the forward slash.
 - "LITTLEFS_SOURCE": ""
-  - Path to an optional local installation of littlefs source files. If no path is given, then CMake will download the sources automatically from littlefs repository when required. Mind the forward slash.
+  - Path to an optional local installation of littlefs source files. If no path is given, then CMake will download the sources automatically. Mind the forward slash.
 - "FATFS_SOURCE": ""
-  - Path to an optional local installation of FatFS source files. If no path is given, then CMake will download the sources automatically from FatFS repository when required. Mind the forward slash.
-- "FATFS_VERSION": ""
-  - Valid FatFS version. If empty use default CMake setting.
-- "LWIP_VERSION": ""
-  - Valid lwIP version. If empty use default CMake setting.
-- "ESP32_XTAL_FREQ_26": **`OFF`**
-  - Set to ON to enable XTAL frequency to 26M.
-- "ESP32_USB_CDC": **`OFF`**
-  - Set to ON to enable embedded USB CDC. Valid for ESP32_S2 series.
-- "ESP32_ETHERNET_SUPPORT": **`OFF`**
-  - Set to ON to enable Ethernet support for ESP32 target.
-- "SDK_CONFIG_FILE": ""
-  - Path to an optional location of IDF SDK config file. If no path is given, then CMake will build one according to the target and relevant build options.
-- "SWO_OUTPUT" : **`OFF`**
-  - Allows specifying whether to include, or not, support for Cortex-M Single Wire Output (SWO). Default is `OFF`. Check the documentation [here](../contributing/developing-native/arm-swo.md) for more details on how to use SWO.
-- "NF_BUILD_RTM" : **`OFF`**
-  - Sets the build to be **R**elease **T**o **M**anufacturing type. Meaning that all debugger features, instrumentation and debug helper code will be removed from compilation. The build will be compiled and linked with all possible code reducing options enabled. An RTM build doesn't have debugging capabilities, meaning that a debug session can not be started. In order to deploy to a device running an RTM build `nanoff` CLI should be used or any other mean that can flash the deployment region.
-- "NF_TRACE_TO_STDIO": **`OFF`**
-  - Set to ON to enable trace messages to stdio.
-- "NF_WP_TRACE_ERRORS" : **`OFF`**
-  - Enable error tracing in Wire Protocol.
-- "NF_WP_TRACE_HEADERS" :  **`OFF`**
-  - Enable packet headers tracing in Wire Protocol.
-- "NF_WP_TRACE_STATE" :  **`OFF`**
-  - Enable state tracing in Wire Protocol.
-- "NF_WP_TRACE_NODATA" :  **`OFF`**
-  - Enable tracing of empty or incomplete packets in Wire Protocol.
-- "NF_WP_TRACE_ALL" :  **`OFF`**
-  - Enable all tracing options for Wire Protocol.
-- "NF_WP_IMPLEMENTS_CRC32" :  **`ON`**
-  - Enable CRC32 calculations for Wire Protocol. See details [here](../architecture/wire-protocol.md#crc32-validations).
-- "NF_FEATURE_DEBUGGER" : **`OFF`**
-  - Defines is support for debuggin managed applications is enabled. Default is `OFF`.
-- "NF_FEATURE_RTC" : **`OFF`**
-  - Allows you to specify whether to use the real time clock unit of the hardware for date & time functions. Depends on target availability. Default is `OFF`.
-- "NF_FEATURE_USE_APPDOMAINS" : **`OFF`**
-  - Allows you to specify whether to include, or not, support for Application Domains. Default is `OFF`. More information about this is available in the [MSDN documentation on Application Domains](https://msdn.microsoft.com/en-us/library/cxk374d9(v=vs.90).aspx). **Note that the complete removal of support for this feature is being considered.**
-- "NF_FEATURE_SUPPORT_REFLECTION": "ON"
-  - Set to `OFF` to disable support for System.Reflection API.
-- "NF_FEATURE_BINARY_SERIALIZATION": **`ON`**
-  - Set to `OFF` to disable support for binary serialization/deserialization. This is only applicable with NF_FEATURE_SUPPORT_REFLECTION set to `ON`.
-- "NF_FEATURE_WATCHDOG" : **`ON`**
-  - Allows you to define it the hardware watchdog should be disabled.
-   This setting can only be set to `OFF` for STM32 targets. ESP32 build enables this by default so there is no way to disable it.
-   Default is ON, so the hardware watchdog will be enabled by default.
-- "NF_FEATURE_HAS_CONFIG_BLOCK" : **`OFF`**
-  - Allows the developer to set if the targets platform has configuration block.
-  This requires the the block storage definition and the linker files add support for that.
-  Default is `OFF` meaning that that the target DOES NOT have configuration block.
-- "NF_PLATFORM_NO_CLR_TRACE" : **`OFF`**
-  - Allows you to define if trace messages and checks are added to CLR or not.
-  These checks are usually valuable when debugging issues within the CLR.
-  Can and should be removed for RTM build flavours.
-  Default is `OFF` meaning that all the standard trace and checks are added to the CLR.
-- "NF_CLR_NO_IL_INLINE" : **`OFF`**
-  - Allows you to define if CLR will use IL inlining.
-  Default is `OFF` meaning that CLR will inline IL.
+  - Path to an optional local installation of FatFS source files. If no path is given, then CMake will download the sources automatically. Mind the forward slash.
+- "MBEDTLS_SOURCE" : ""
+  - Path to an optional local with mbedTLS source files.
 - "NF_INTEROP_ASSEMBLIES" : "Assembly1-Namespace Assembly2-Namespace Assembly3-Namespace"
   - Lists the name of the Interop assembly(ies) to be added to the build in a space separated string. Leave empty or don't add it if no Interop assembly is to be added.
-- "NF_NETWORKING_SNTP" : **`ON`**
-  - Allows you to specify whether SNTP is enabled. Requires networking feature to be enabled. Default is ON.
-- "NF_SECURITY_MBEDTLS" : **`OFF`**
-  - Enables support for secure sockets using mbedTLS. Default is `OFF`.
-- "MBEDTLS_SOURCE" : **`OFF`**
-  - Path to an optional local with mbedTLS source files.
-- "API_nanoFramework.Device.OneWire" : **`OFF`**
-  - Allows you to specify whether support for OneWire functions are available to your application. Default is `OFF`.
-- "API_System.Device.Dac" : **`OFF`**
-  - Allows you to specify whether DAC functions are available to your application. Default is `OFF`.
-- "API_System.Math" : **`OFF`**
-  - Allows you to specify whether System.Math support is available to your application. Default is `OFF`.
-- "API_System.Net" : **`OFF`**
-  - Allows you to specify whether System.Net support is available to your application. Default is `OFF`.
-- "API_nanoFramework.Device.Can" : **`OFF`**
-  - Allows you to specify whether CAN bus functions are available to your application. Default is `OFF`.
-- "API_System.Device.Adc" : **`OFF`**
-  - Allows you to specify whether ADC functions are available to your application. Default is `OFF`.
-- "API_System.Device.Gpio" : **`OFF`**
-  - Allows you to specify whether GPIO functions are available to your application. Default is `OFF`.
-- "API_System.Device.I2c" : **`OFF`**
-  - Allows you to specify whether I2C functions are available to your application. Default is `OFF`.
-- "API_System.Device.Pwm" : **`OFF`**
-  - Allows you to specify whether PWM functions are available to your application. Default is `OFF`.
-- "API_System.IO.Ports" : **`OFF`**
-  - Allows you to specify whether Serial Communication functions are available to your application. Default is `OFF`.
-- "API_System.Device.Spi" : **`OFF`**
-  - Allows you to specify whether SPI functions are available to your application. Default is `OFF`.
-- "API_Windows.Networking.Sockets" : **`OFF`**
-  - Allows you to specify whether Networking Sockets functions are available to your application. Default is `OFF`.
-- "API_Windows.Storage" : **`OFF`**
-  - Allows you to specify whether Windows.Storage functions are available to your application. Default is `OFF`.
-- "API_Hardware.Esp32" : **`OFF`**
-  - Allows you to specify whether Hardware.Esp32 functions are available to your application. Default is `OFF`.
-  Note that this API is exclusive of ESP32 targets and can't be used with any other.
-- "API_Hardware.Stm32" : **`OFF`**
-  - Allows you to specify whether Hardware.Stm32 functions are available to your application. Default is `OFF`.
-  Note that this API is exclusive of STM32 targets and can't be used with any other.
-- "API_nanoFramework.ResourceManager" : **`OFF`**
-- "API_nanoFramework.TI.EasyLink" : **`OFF`**
-  - Allows you to specify whether TI.EasyLink functions are available to your application. Default is `OFF`.
-  Note that this API is exclusive for TI targets and can't be used with any other.
-- "API_nanoFramework.Hardware.TI" : **`OFF`**
-  - Allows you to specify whether Hardware.TI functions are available to your application. Default is `OFF`.
-    Note that this API is exclusive for TI targets and can't be used with any other.
-- "API_nanoFramework.System.Collections" : **`OFF`**
-  - Allows you to specify whether System.Collections functions are available to your application. Default is `OFF`.
-- "API_nanoFramework.System.Text" : **`OFF`**
-  - Allows you to specify whether System.Text functions are available to your application. Default is `OFF`.
-- "API_System.Device.Wifi" : **`OFF`**
-  - Allows you to specify whether Device.Wifi functions are available to your application. Default is `OFF`.
-  Note that this API is exclusive of ESP32 targets and can't be used with any other.
-- "API_nanoFramework.Device.Bluetooth" : **`OFF`**
-  - Allows you to specify whether Device.Bluetooth functions are available to your application. Default is `OFF`.
-  Note that this API is exclusive of ESP32 targets and can't be used with any other.
-- "API_System.IO.FileSystem" : **`OFF`**
-  - Allows you to specify whether System.IO.FileSystem functions are available to your application. Default is `OFF`.
-- "API_nanoFramework.Graphics" : **`OFF`**
-  - Allows you to specify whether Graphics functions are available to your application. Default is `OFF`.
-  Note that this API has the following sub options required depending on target:
-    - "GRAPHICS_MEMORY"
-    - "GRAPHICS_DISPLAY"
-    - "GRAPHICS_DISPLAY_INTERFACE"
-    - "TOUCHPANEL_DEVICE"
-    - "TOUCHPANEL_INTERFACE"
-- "NF_FEATURE_HAS_SDCARD" : **`OFF`**
-  - Set to ON to enable support for SDCard storage device.
+- "NF_TARGET_DEFCONFIG" : "**path-to-target-defconfig-file**"
+  - Path to the Kconfig defconfig file for the target board. This is the only target-specific variable in a CMake preset. All hardware/feature/API configuration is read from this defconfig file by the Kconfig system.
+
+## Deprecated CMake Preset Options
+
+The following options have been **migrated to [Kconfig](kconfig-options.md)** and are no longer set in CMake presets. See the [Kconfig options](kconfig-options.md) page for their Kconfig equivalents.
+
+### Platform identity (now in Kconfig)
+
+- `TARGET_BOARD`, `TARGET_SERIES`, `RTOS`
+
+### Build mode flags (now in Kconfig)
+
+- `NF_BUILD_RTM`, `NF_TARGET_HAS_NANOBOOTER`, `NF_SECURITY_MBEDTLS`, `NF_ENABLE_DOUBLE_PRECISION_FP`, `NF_SUPPORT_ANY_BASE_CONVERSION`, `NF_FEATURE_USE_RNG`
+
+### nF features (now in Kconfig)
+
+- `NF_FEATURE_DEBUGGER`, `NF_FEATURE_RTC`, `NF_FEATURE_HAS_SDCARD`, `NF_FEATURE_HAS_CONFIG_BLOCK`, `NF_FEATURE_USE_LITTLEFS`, `NF_FEATURE_HAS_USB_MSD`, `NF_FEATURE_HAS_ACCESSIBLE_STORAGE`, `NF_FEATURE_WATCHDOG`, `NF_FEATURE_SUPPORT_REFLECTION`, `NF_FEATURE_BINARY_SERIALIZATION`, `NF_FEATURE_LIGHT_MATH`, `NF_FEATURE_USE_APPDOMAINS`
+
+### Wire Protocol (now in Kconfig)
+
+- `NF_WP_TRACE_ERRORS`, `NF_WP_TRACE_HEADERS`, `NF_WP_TRACE_STATE`, `NF_WP_TRACE_NODATA`, `NF_WP_TRACE_ALL`, `NF_WP_ENABLE_CRC32`
+
+### CLR options (now in Kconfig)
+
+- `NF_CLR_NO_TRACE`, `NF_CLR_NO_IL_INLINE`, `NF_TRACE_TO_STDIO`
+
+### Wire Protocol transport (now in Kconfig)
+
+- `NF_WP_TRANSPORT_SERIAL`, `NF_WP_TRANSPORT_USB_CDC`, `TARGET_SERIAL_BAUDRATE`
+
+### API selection (now in Kconfig)
+
+- All `API_System.*`, `API_nanoFramework.*`, `API_Hardware.*`, `API_Windows.*` variables
+
+### Graphics (now in Kconfig)
+
+- `GRAPHICS_DISPLAY`, `GRAPHICS_DISPLAY_INTERFACE`, `TOUCHPANEL_DEVICE`, `TOUCHPANEL_INTERFACE`, `GRAPHICS_MEMORY`
+
+### ESP32-specific (now in Kconfig)
+
+- `ESP32_ETHERNET_SUPPORT`, `ESP32_ETHERNET_INTERFACE`, `ESP32_USB_CDC`, `ESP32_RESERVE_SPIRAM_IDF_ALLOCATION_BYTES`, `ESP32_XTAL_FREQ_26`, `SDK_CONFIG_FILE`
+
+### STM32/ChibiOS-specific (now in Kconfig)
+
+- `THREADX_CHIBIOS_HAL_REQUIRED`, `CHIBIOS_CONTRIB_REQUIRED`, `STM32_CUBE_PACKAGE_REQUIRED`, `CHIBIOS_SWO_OUTPUT`, `TARGET_NAME`
+
+### TI SimpleLink-specific (now in Kconfig)
+
+- `TI_SIMPLELINK_RADIO_FREQ_MHZ`
+
+### Networking (now in Kconfig)
+
+- `NF_NETWORKING_SNTP`
 - "NF_FEATURE_HAS_USB_MSD" : **`OFF`**
   - Set to ON to enable support for USB Mass storage device.
 - "NF_FEATURE_USE_SPIFFS": **`OFF`**
@@ -257,21 +130,23 @@ Below is a list of the build options available (last updated October 2022). Thes
   Note that this API has the following sub options:
     - "ESP32_ETHERNET_INTERFACE":
       - Type of PHY or SPI device used leave empty to use default Lan8720.
-    - "ETH_PHY_RST_GPIO"
+    - "ESP32_ETHERNET_PHY_RST_GPIO"
       - GPIO number for PHY reset leave empty to use default of none.
-    - "ETH_RMII_CLK_OUT_GPIO"
+    - "ESP32_ETHERNET_RMII_CLK_OUT_GPIO"
       - GPIO number that will output the RMII CLK signal leave empty if not used.
-    - "ETH_RMII_CLK_IN_GPIO"
+    - "ESP32_ETHERNET_RMII_CLK_IN_GPIO"
       - GPIO number that will be input for RMII CLK signal leave empty if not used.
-    - "ETH_PHY_ADDR": ""
+    - "ESP32_ETHERNET_PHY_ADDR": ""
       - Address of the PHY chip leave empty to use default.
-    - "ETH_MDC_GPIO": ""
+    - "ESP32_ETHERNET_MDC_GPIO": ""
       - GPIO number for SMI MDC pin leave empty to use default.
-    - "ETH_MDIO_GPIO": ""
+    - "ESP32_ETHERNET_MDIO_GPIO": ""
       - GPIO number for SMI MDIO pin leave empty to use default.
-- "ESP32_CONFIG_PIN_PHY_POWER" : Not used?!
-- "ESP32_CONFIG_PHY_CLOCK_MODE" : Not used?!
-- "ESP32_SPIRAM_FOR_IDF_ALLOCATION" : ""
+- "ESP32_ETHERNET_PHY_POWER_PIN" : ""
+  - Ethernet PHY power pin override.
+- "ESP32_ETHERNET_PHY_CLOCK_MODE" : ""
+  - Ethernet PHY clock mode override.
+- "ESP32_RESERVE_SPIRAM_IDF_ALLOCATION_BYTES" : ""
   - Set a value to reserve from SPI RAM for IDF allocation.
 - "NF_TARGET_HAS_NANOBOOTER" : **`ON`**
   - Set to `OFF` to signal that target does not have nanoBooter.

--- a/content/building/index.md
+++ b/content/building/index.md
@@ -3,6 +3,7 @@
 * [Building .NET **nanoFramework** firmware](build-instructions.md)
 * [Build using local source for RTOS](rtos-source-for-build.md)
 * [CMake presets](cmake-presets.md)
+* [Kconfig target configuration](kconfig-options.md)
 * [Building in Visual Studio](build-in-visual-studio.md)
 
 ## ChibiOS HAL

--- a/content/building/kconfig-options.md
+++ b/content/building/kconfig-options.md
@@ -1,0 +1,377 @@
+# Kconfig Target Configuration
+
+## About this document
+
+This document describes the Kconfig-based target configuration system used to configure hardware features, APIs and build options for .NET **nanoFramework** firmware targets.
+
+## Introduction
+
+Target and hardware/feature configuration uses [Kconfig](https://www.kernel.org/doc/html/latest/kbuild/kconfig-language.html), powered by [kconfiglib](https://github.com/ulfalizer/Kconfiglib) (a pure-Python implementation). CMake presets remain for build-system configuration (toolchain, generator, output paths, tool paths) — see [CMake presets](cmake-presets.md).
+
+Each target board has a `defconfig` file that contains only the non-default configuration values. Kconfig fills in all remaining options with their defaults, enforces dependencies and validates the configuration at configure time.
+
+### Prerequisites
+
+- [Python 3.8](https://www.python.org/downloads/) or later.
+- [kconfiglib](https://github.com/ulfalizer/Kconfiglib): install with `pip install kconfiglib`.
+
+### Key benefits
+
+- **Interactive configuration**: use `menuconfig` to discover and toggle options.
+- **Declarative dependencies**: `depends on`, `select` and `imply` replace hardcoded CMakeLists.txt conditionals.
+- **Minimal defconfig files**: only non-default values are stored, reducing per-target boilerplate.
+- **Validation**: Kconfig enforces constraints at configuration time, not at build time.
+
+## Developer Workflow
+
+### Building an existing target
+
+The workflow is unchanged from the developer's perspective:
+
+```bash
+cmake --preset ESP32_PSRAM_REV0
+cmake --build --preset ESP32_PSRAM_REV0
+```
+
+The preset loads the defconfig automatically via the `NF_TARGET_DEFCONFIG` cache variable. If `config/user-kconfig.conf` is present, its preferences are merged on top transparently.
+
+### Applying developer-local preferences
+
+Developer-local Kconfig preferences (RTM mode, CLR trace flags, Wire Protocol options, etc.) are set in `config/user-kconfig.conf`:
+
+```bash
+# First time only — copy the template
+cp config/user-kconfig.conf.TEMPLATE config/user-kconfig.conf
+```
+
+Edit the file using standard Kconfig fragment format:
+
+```text
+CONFIG_NF_BUILD_RTM=n
+CONFIG_NF_CLR_NO_TRACE=n
+CONFIG_NF_CLR_NO_IL_INLINE=n
+CONFIG_NF_WP_TRACE_ERRORS=n
+CONFIG_NF_WP_ENABLE_CRC32=n
+```
+
+This file is git-ignored. Only symbols explicitly listed in the overlay are modified; everything else comes from the board defconfig.
+
+### Interactive configuration with menuconfig
+
+```bash
+# Load defconfig into .config
+python -m defconfig targets/ESP32/defconfig/ESP32_PSRAM_REV0_defconfig
+
+# Open menu-driven configuration
+python -m menuconfig
+
+# Build as usual
+cmake --preset ESP32_PSRAM_REV0
+cmake --build --preset ESP32_PSRAM_REV0
+```
+
+### Creating a new target
+
+```bash
+# Start from closest existing defconfig
+cp targets/ESP32/defconfig/ESP32_PSRAM_REV0_defconfig targets/ESP32/defconfig/MY_BOARD_defconfig
+
+# Edit interactively
+export KCONFIG_CONFIG=build/.config
+python -m defconfig targets/ESP32/defconfig/MY_BOARD_defconfig
+python -m menuconfig
+
+# Save minimal defconfig (only non-default values)
+python -m savedefconfig --out targets/ESP32/defconfig/MY_BOARD_defconfig
+```
+
+### Modifying an existing target configuration
+
+```bash
+# Load and open for editing
+python -m defconfig targets/ChibiOS/ST_STM32F769I_DISCOVERY/defconfig
+python -m menuconfig
+
+# Save back
+python -m savedefconfig --out targets/ChibiOS/ST_STM32F769I_DISCOVERY/defconfig
+```
+
+## Directory Structure
+
+```text
+nf-interpreter/
+├── Kconfig                              # Root — sources everything
+├── Kconfig.rtos                         # RTOS selection
+├── Kconfig.features                     # NF_FEATURE_* options with dependencies
+├── Kconfig.apis                         # API selection with auto-select dependencies
+├── Kconfig.graphics                     # Graphics display/touch subsystem
+├── Kconfig.networking                   # Networking, Ethernet, WiFi, Thread
+├── Kconfig.serial                       # Wire Protocol transport (UART / USB CDC)
+├── Kconfig.wireprotocol                 # Wire Protocol options and trace flags
+├── Kconfig.build                        # RTM, floating point, base conversion, etc.
+│
+├── config/
+│   ├── user-kconfig.conf.TEMPLATE       # Template for Kconfig-level user preferences
+│   └── user-kconfig.conf                # Developer local copy — git-ignored
+│
+├── targets/
+│   ├── ESP32/
+│   │   ├── Kconfig                      # ESP32 family options
+│   │   ├── Kconfig.ethernet             # ESP32 Ethernet PHY configuration
+│   │   └── defconfig/                   # Flat directory — ESP32 variants
+│   │       ├── ESP32_PSRAM_REV0_defconfig
+│   │       ├── ESP32_BLE_REV0_defconfig
+│   │       └── ...
+│   │
+│   ├── ChibiOS/
+│   │   ├── Kconfig                      # ChibiOS/STM32-specific options
+│   │   └── <board>/
+│   │       └── defconfig                # Per-board defconfig
+│   │
+│   ├── FreeRTOS/
+│   │   ├── Kconfig
+│   │   └── NXP/<board>/defconfig
+│   │
+│   ├── TI_SimpleLink/
+│   │   ├── Kconfig
+│   │   └── <board>/defconfig
+│   │
+│   └── ThreadX/
+│       ├── Kconfig
+│       └── <vendor>/<board>/defconfig
+```
+
+## Kconfig Options Reference
+
+### Platform Identity
+
+| Kconfig Symbol | Type | Description |
+|---|---|---|
+| `TARGET_BOARD` | string | Target board name |
+| `TARGET_SERIES` | string | Target MCU series (e.g. `STM32F7xx`, `ESP32`, `IMXRT10xx`) |
+| `RTOS` | choice | RTOS selection: `ESP32`, `ChibiOS`, `FreeRTOS`, `TI_SimpleLink`, `ThreadX` |
+
+### Build Options
+
+| Kconfig Symbol | Type | Default | Description |
+|---|---|---|---|
+| `NF_BUILD_RTM` | bool | n | Build RTM firmware (suppresses debug output, removes all debugger features) |
+| `NF_TARGET_HAS_NANOBOOTER` | bool | y | Target includes nanoBooter |
+| `NF_ENABLE_DOUBLE_PRECISION_FP` | bool | n | Enable double-precision floating point (default is single-precision) |
+| `NF_SUPPORT_ANY_BASE_CONVERSION` | bool | n | Enable string conversion for any numeric base (default: base 10 and 16 only) |
+| `NF_FEATURE_USE_RNG` | bool | y | Enable hardware true random number generator |
+| `NF_SECURITY_MBEDTLS` | bool | y | Enable Mbed TLS support for secure sockets |
+| `NF_CLR_NO_TRACE` | bool | n | Remove trace messages and checks from CLR |
+| `NF_CLR_NO_IL_INLINE` | bool | n | Disable IL inlining in CLR |
+
+### nanoFramework Features
+
+| Kconfig Symbol | Type | Default | Description |
+|---|---|---|---|
+| `NF_FEATURE_DEBUGGER` | bool | y | Managed application debugging support |
+| `NF_FEATURE_RTC` | bool | n | Hardware RTC support |
+| `NF_FEATURE_HAS_SDCARD` | bool | n | SD Card support |
+| `NF_FEATURE_HAS_CONFIG_BLOCK` | bool | n | Configuration block storage |
+| `NF_FEATURE_USE_LITTLEFS` | bool | n | LittleFS file system |
+| `NF_FEATURE_HAS_ACCESSIBLE_STORAGE` | bool | n | Accessible storage (internal storage) |
+| `NF_FEATURE_HAS_USB_MSD` | bool | n | USB Mass Storage |
+| `NF_FEATURE_WATCHDOG` | bool | y | Hardware watchdog |
+| `NF_FEATURE_SUPPORT_REFLECTION` | bool | y | System.Reflection API support |
+| `NF_FEATURE_BINARY_SERIALIZATION` | bool | y | Binary serialization support |
+| `NF_FEATURE_USE_APPDOMAINS` | bool | n | Application Domains support |
+| `NF_FEATURE_LIGHT_MATH` | bool | n | Light math (exclude complex math functions) |
+| `NF_TRACE_TO_STDIO` | bool | n | Enable trace messages to stdio |
+
+### Wire Protocol
+
+| Kconfig Symbol | Type | Default | Description |
+|---|---|---|---|
+| `NF_WP_TRACE_ERRORS` | bool | n | Enable error tracing in Wire Protocol |
+| `NF_WP_TRACE_HEADERS` | bool | n | Enable packet headers tracing |
+| `NF_WP_TRACE_STATE` | bool | n | Enable state tracing |
+| `NF_WP_TRACE_NODATA` | bool | n | Enable tracing of empty or incomplete packets |
+| `NF_WP_TRACE_VERBOSE` | bool | n | Enable verbose tracing |
+| `NF_WP_TRACE_ALL` | bool | n | Enable all tracing options |
+| `NF_WP_ENABLE_CRC32` | bool | n | Enable CRC32 calculations. See [Wire Protocol details](../architecture/wire-protocol.md#crc32-validations) |
+
+### Wire Protocol Transport
+
+| Kconfig Symbol | Type | Default | Description |
+|---|---|---|---|
+| `NF_WP_TRANSPORT_SERIAL` | bool | y | Use serial (UART) for Wire Protocol (default transport) |
+| `NF_WP_TRANSPORT_USB_CDC` | bool | n | Use USB CDC for Wire Protocol |
+| `TARGET_SERIAL_BAUDRATE` | int | 921600 | Baudrate for serial communication (depends on `NF_WP_TRANSPORT_SERIAL`) |
+
+### API Selection
+
+API options follow the pattern `API_<name>` in Kconfig. Kconfig automatically enforces dependencies between APIs.
+
+| Kconfig Symbol | Type | Default | Description |
+|---|---|---|---|
+| `API_SYSTEM_MATH` | bool | y | System.Math |
+| `API_SYSTEM_NET` | bool | n | System.Net (auto-selects `NF_FEATURE_HAS_CONFIG_BLOCK`) |
+| `API_SYSTEM_DEVICE_GPIO` | bool | y | System.Device.Gpio |
+| `API_SYSTEM_DEVICE_SPI` | bool | n | System.Device.Spi |
+| `API_SYSTEM_DEVICE_I2C` | bool | n | System.Device.I2c |
+| `API_SYSTEM_DEVICE_I2C_SLAVE` | bool | n | System.Device.I2c.Slave (depends on `API_SYSTEM_DEVICE_I2C`) |
+| `API_SYSTEM_DEVICE_PWM` | bool | n | System.Device.Pwm |
+| `API_SYSTEM_DEVICE_ADC` | bool | n | System.Device.Adc |
+| `API_SYSTEM_DEVICE_DAC` | bool | n | System.Device.Dac |
+| `API_SYSTEM_DEVICE_I2S` | bool | n | System.Device.I2s |
+| `API_SYSTEM_DEVICE_WIFI` | bool | n | System.Device.Wifi |
+| `API_SYSTEM_DEVICE_USBSTREAM` | bool | n | System.Device.UsbStream |
+| `API_SYSTEM_IO_PORTS` | bool | n | System.IO.Ports (auto-selects `API_NANOFRAMEWORK_SYSTEM_TEXT`) |
+| `API_SYSTEM_IO_FILESYSTEM` | bool | n | System.IO.FileSystem (depends on `NF_FEATURE_HAS_SDCARD`, `NF_FEATURE_USE_LITTLEFS` or `NF_FEATURE_HAS_USB_MSD`) |
+| `API_NANOFRAMEWORK_DEVICE_ONEWIRE` | bool | n | nanoFramework.Device.OneWire |
+| `API_NANOFRAMEWORK_DEVICE_CAN` | bool | n | nanoFramework.Device.Can |
+| `API_NANOFRAMEWORK_DEVICE_BLUETOOTH` | bool | n | nanoFramework.Device.Bluetooth |
+| `API_NANOFRAMEWORK_GRAPHICS` | bool | n | nanoFramework.Graphics |
+| `API_NANOFRAMEWORK_RESOURCEMANAGER` | bool | n | nanoFramework.ResourceManager |
+| `API_NANOFRAMEWORK_SYSTEM_COLLECTIONS` | bool | n | nanoFramework.System.Collections |
+| `API_NANOFRAMEWORK_SYSTEM_TEXT` | bool | n | nanoFramework.System.Text |
+| `API_NANOFRAMEWORK_SYSTEM_SECURITY_CRYPTOGRAPHY` | bool | n | nanoFramework.System.Security.Cryptography (depends on `NF_SECURITY_MBEDTLS`) |
+| `API_NANOFRAMEWORK_SYSTEM_IO_HASHING` | bool | n | nanoFramework.System.IO.Hashing |
+| `API_NANOFRAMEWORK_NETWORKING_THREAD` | bool | n | nanoFramework.Networking.Thread |
+
+### Platform-Specific APIs
+
+These APIs are only visible when the corresponding RTOS is selected.
+
+| Kconfig Symbol | Type | Depends On | Description |
+|---|---|---|---|
+| `API_HARDWARE_ESP32` | bool | `RTOS_ESP32` | Hardware.Esp32 |
+| `API_NANOFRAMEWORK_HARDWARE_ESP32_RMT` | bool | `RTOS_ESP32` | nanoFramework.Hardware.Esp32.Rmt |
+| `API_HARDWARE_STM32` | bool | `RTOS_CHIBIOS` | Hardware.Stm32 |
+| `API_NANOFRAMEWORK_HARDWARE_TI` | bool | `RTOS_TI_SIMPLELINK` | nanoFramework.Hardware.TI |
+| `API_NANOFRAMEWORK_TI_EASYLINK` | bool | `RTOS_TI_SIMPLELINK` | nanoFramework.TI.EasyLink |
+| `API_HARDWARE_GIANTGECKO` | bool | `RTOS_THREADX` | Hardware.GiantGecko |
+| `API_NANOFRAMEWORK_GIANTGECKO_ADC` | bool | `RTOS_THREADX` | nanoFramework.GiantGecko.Adc |
+
+### Graphics Options
+
+These options are available when `API_NANOFRAMEWORK_GRAPHICS` is enabled.
+
+| Kconfig Symbol | Type | Description |
+|---|---|---|
+| `GRAPHICS_DISPLAY` | choice | Display driver: ILI9341, ILI9342, ST7735S, ST7789V, GC9A01, Otm8009a (DSI), Generic SPI |
+| `GRAPHICS_DISPLAY_INTERFACE` | choice | Display interface: SPI to Display, DSI Video Mode |
+| `TOUCHPANEL_DEVICE` | choice | Touch panel driver: XPT2046, ft6x06, CST816S (optional) |
+| `TOUCHPANEL_INTERFACE` | choice | Touch panel interface: SPI, I2C (optional) |
+| `GRAPHICS_MEMORY` | string | Graphics memory implementation |
+
+### ESP32-Specific Options
+
+Available when RTOS is set to ESP32.
+
+| Kconfig Symbol | Type | Default | Description |
+|---|---|---|---|
+| `SDK_CONFIG_FILE` | string | "" | Path to IDF sdkconfig defaults file |
+| `ESP32_RESERVE_SPIRAM_IDF_ALLOCATION_BYTES` | int | 262144 | SPIRAM reserved for IDF allocation (bytes) |
+| `ESP32_USB_CDC` | bool | n | USB CDC for Wire Protocol |
+| `ESP32_XTAL_FREQ_26` | bool | n | 26 MHz crystal (instead of 40 MHz default) |
+| `ESP32_RESERVE_IRAM_IDF_ALLOCATION_KB` | int | 0 | RAM reserved for IDF allocation (kB, for limited-memory boards) |
+| `ESP32_ETHERNET_SUPPORT` | bool | n | Enable Ethernet support |
+| `ESP32_THREAD_DEVICE_TYPE` | string | "" | Thread device type |
+| `ESP32_ETHERNET_PHY_CLOCK_MODE` | string | "" | Ethernet PHY clock mode override |
+| `ESP32_ETHERNET_PHY_POWER_PIN` | string | "" | Ethernet PHY power pin override |
+
+#### ESP32 Ethernet Sub-options
+
+Available when `ESP32_ETHERNET_SUPPORT` is enabled.
+
+| Kconfig Symbol | Type | Default | Description |
+|---|---|---|---|
+| `ESP32_ETHERNET_INTERFACE` | choice | — | Ethernet PHY: IP101, LAN8720, RTL8201 |
+| `ESP32_ETHERNET_PHY_ADDR` | int | 1 | Ethernet PHY address |
+| `ESP32_ETHERNET_MDC_GPIO` | int | 23 | MDC GPIO pin |
+| `ESP32_ETHERNET_MDIO_GPIO` | int | 18 | MDIO GPIO pin |
+| `ESP32_ETHERNET_RMII_CLK_OUT_GPIO` | int | -1 | RMII clock output GPIO pin (-1 = not used) |
+| `ESP32_ETHERNET_RMII_CLK_IN_GPIO` | int | -1 | RMII clock input GPIO pin (-1 = not used) |
+| `ESP32_ETHERNET_PHY_RST_GPIO` | int | -1 | Ethernet PHY reset GPIO pin (-1 = not used) |
+
+### ChibiOS/STM32-Specific Options
+
+Available when RTOS is set to ChibiOS.
+
+| Kconfig Symbol | Type | Default | Description |
+|---|---|---|---|
+| `CHIBIOS_CONTRIB_REQUIRED` | bool | n | Include ChibiOS Contrib repository in the build |
+| `STM32_CUBE_PACKAGE_REQUIRED` | bool | n | Include STM Cube package in the build |
+| `CHIBIOS_SWO_OUTPUT` | bool | n | Support for Cortex-M Single Wire Output (SWO). See [SWO details](../contributing/developing-native/arm-swo.md) |
+
+### ThreadX-Specific Options
+
+Available when RTOS is set to ThreadX.
+
+| Kconfig Symbol | Type | Default | Description |
+|---|---|---|---|
+| `GECKO_FEATURE_USBD_HID` | bool | n | Gecko USB HID device support |
+| `STM32_CUBE_PACKAGE_REQUIRED` | bool | n | Include STM Cube package in the build |
+| `THREADX_CHIBIOS_HAL_REQUIRED` | bool | n | ChibiOS HAL required (for STM32 WiFi targets) |
+| `THREADX_WIFI_DRIVER` | string | "" | WiFi driver name (e.g. ISM43362) |
+
+### TI SimpleLink-Specific Options
+
+Available when RTOS is set to TI SimpleLink.
+
+| Kconfig Symbol | Type | Default | Description |
+|---|---|---|---|
+| `TI_SIMPLELINK_RADIO_FREQ_MHZ` | int | 915 | Radio frequency for CC13xx_26xx targets (868 or 915) |
+
+### Networking Options
+
+| Kconfig Symbol | Type | Default | Description |
+|---|---|---|---|
+| `NF_NETWORKING_SNTP` | bool | y | Enable SNTP (requires networking feature) |
+| `NF_NETWORKING_ENC28J60` | bool | n | Enable ENC28J60 Ethernet controller support |
+
+## Defconfig File Example
+
+A typical defconfig file for an ESP32 target (`targets/ESP32/defconfig/ESP32_PSRAM_REV0_defconfig`):
+
+```text
+CONFIG_TARGET_BOARD="ESP32"
+CONFIG_TARGET_SERIES="ESP32"
+CONFIG_RTOS_ESP32=y
+
+CONFIG_NF_FEATURE_DEBUGGER=y
+CONFIG_NF_FEATURE_RTC=y
+CONFIG_NF_FEATURE_HAS_SDCARD=y
+
+CONFIG_API_SYSTEM_MATH=y
+CONFIG_API_SYSTEM_DEVICE_ADC=y
+CONFIG_API_SYSTEM_DEVICE_DAC=y
+CONFIG_API_SYSTEM_DEVICE_GPIO=y
+CONFIG_API_SYSTEM_DEVICE_I2C=y
+CONFIG_API_SYSTEM_DEVICE_PWM=y
+CONFIG_API_SYSTEM_IO_PORTS=y
+CONFIG_API_SYSTEM_DEVICE_SPI=y
+CONFIG_API_NANOFRAMEWORK_DEVICE_ONEWIRE=y
+CONFIG_API_NANOFRAMEWORK_RESOURCEMANAGER=y
+CONFIG_API_NANOFRAMEWORK_SYSTEM_COLLECTIONS=y
+CONFIG_API_NANOFRAMEWORK_SYSTEM_TEXT=y
+
+CONFIG_ESP32_RESERVE_SPIRAM_IDF_ALLOCATION_BYTES=262144
+```
+
+Only non-default values appear in the defconfig. Kconfig fills in the rest.
+
+## CMake Integration
+
+The Kconfig system integrates with CMake through `NF_Kconfig.cmake`. During configuration:
+
+1. `scripts/nf_merge_config.py` merges the board defconfig with the optional `config/user-kconfig.conf` overlay into `build/.config`.
+2. `genconfig` produces `build/.config` and `build/nf_config.h`.
+3. `NF_Kconfig.cmake` parses `.config` into CMake cache variables.
+
+Kconfig symbol names are mapped to CMake variable names automatically:
+
+| Kconfig symbol | CMake variable |
+|---|---|
+| `CONFIG_NF_FEATURE_DEBUGGER=y` | `NF_FEATURE_DEBUGGER=ON` |
+| `CONFIG_API_SYSTEM_DEVICE_GPIO=y` | `API_System.Device.Gpio=ON` |
+| `CONFIG_API_NANOFRAMEWORK_GRAPHICS=y` | `API_nanoFramework.Graphics=ON` |
+| `CONFIG_TARGET_BOARD="ESP32"` | `TARGET_BOARD=ESP32` |
+| `CONFIG_RTOS="ChibiOS"` | `RTOS=ChibiOS` |
+
+All existing CMake modules continue to work unchanged.


### PR DESCRIPTION
## Description
- Add documentation for Kconfig options and how to use.
- Update doc for CMake preset.
- Update build instructions with requirement for Python.

## Motivation and Context
- Following nanoframework/nf-interpreter#3275

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (correction, content improvement, typo fix, formatting)
- [x] New Article (new document for docs website)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My doc follows the code style of this project.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
