### PR TITLE
Update getting-started-managed.md with correct runtime

### DIFF
--- a/content/getting-started-guides/getting-started-managed.md
+++ b/content/getting-started-guides/getting-started-managed.md
@@ -38,7 +38,7 @@ You need to know the COM Port attached to your device. Search for **Computer Man
 
 > NOTE
 >
-> - The [.NET 6.0 Runtime (or .NET 6.0 SDK) or higher](https://dotnet.microsoft.com/download) must be installed to make use of the nano Firmware Flasher.
+> - The [.NET 8.0 Runtime (or .NET 8.0 SDK)](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) must be installed to make use of the nano Firmware Flasher.
 
 ![Installing nanoff and flashing](../../images/getting-started-guides/getting-started-install-nanoff-flash-esp32.gif)
 


### PR DESCRIPTION
The `nanoff` application as of 2026-08-16 specifies .NET 8.0, and an installation of .NET 10.0.11 does not suffice.  This MR updates the documentation to point to the correct runtime, as specified by the software itself:

<img width="1396" height="528" alt="image" src="https://github.com/user-attachments/assets/4dc7b98a-5126-43ab-962f-3e0bb146dde0" />

Installation via `winget install Microsoft.DotNet.Runtime.8` resolved the issue and `nanoff` ran as expected.

## Description
This updates the documentation to point to the correct required runtime.

## Motivation and Context
Intent is to reduce potential anomalies while beginners are starting to use the software.

## Types of changes
- [x] Improvement (correction, content improvement, typo fix, formatting)
- [ ] New Article (new document for docs website)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My doc follows the code style of this project.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
